### PR TITLE
Fix Celery Beat read-only file system error (issue #33)

### DIFF
--- a/deployment/systemd/django-celery-beat.service
+++ b/deployment/systemd/django-celery-beat.service
@@ -16,7 +16,8 @@ ExecStart=/home/django/platform.wafer.space/.venv/bin/celery \
     beat \
     --loglevel=info \
     --logfile=/var/log/platform.wafer.space/celery-beat.log \
-    --pidfile=/run/platform.wafer.space/celery-beat.pid
+    --pidfile=/run/platform.wafer.space/celery-beat.pid \
+    --schedule=/run/platform.wafer.space/celerybeat-schedule
 
 # Security hardening
 NoNewPrivileges=true


### PR DESCRIPTION
## Summary

- Fixes Celery Beat startup failure caused by read-only file system error
- Configures schedule file to write to `/run` directory instead of working directory
- Single line change to systemd service configuration

## Problem

Celery Beat was failing on startup with:
```
OSError(30, 'Read-only file system'): 'celerybeat-schedule'
```

This occurred because:
- Celery Beat defaults to writing `celerybeat-schedule` file to the current working directory
- Working directory (`/home/django/platform.wafer.space`) is configured as read-only for security hardening
- Only `/var/log`, `/run`, and `/media` directories are writable in the systemd service

## Solution

Added `--schedule=/run/platform.wafer.space/celerybeat-schedule` argument to the Celery Beat command in the systemd service file. This:
- Directs the schedule file to an already-writable location (`/run` directory)
- Follows the same pattern as PID files used by other services
- Maintains security hardening while allowing Celery Beat to function

## Testing

This is a deployment configuration change that cannot be tested locally without replicating the production systemd environment. The fix follows established patterns:
- PID files already use `/run/platform.wafer.space/` directory
- `/run` directory is explicitly listed in `ReadWritePaths` in the service file
- Celery documentation confirms `--schedule` accepts absolute paths

## Closes

Fixes #33

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for the background task scheduler service to specify a dedicated schedule file location. This ensures proper task scheduling operations in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->