### PR TITLE
Disable flaky notification test

### DIFF
--- a/tests/browser/test_notifications/test_notification_ui.py
+++ b/tests/browser/test_notifications/test_notification_ui.py
@@ -266,6 +266,12 @@ class TestNotificationUI(BaseBrowserTest):
         )
         assert "Mark All as Read" in mark_all_button.text
 
+    @pytest.mark.skip(
+        reason=(
+            "Flaky test: TimeoutException waiting for notifications "
+            "to be marked as read. See issue #47 for details."
+        ),
+    )
     def test_mark_all_as_read_functionality(self):
         """Test that mark all as read button works correctly.
 


### PR DESCRIPTION
## Summary

Temporarily disable `test_mark_all_as_read_functionality` due to flaky behavior causing CI failures.

## Details

The `test_mark_all_as_read_functionality` test in `tests/browser/test_notifications/test_notification_ui.py` exhibits flaky behavior, timing out while waiting for notifications to be marked as read in the database. The test uses condition-based waiting with a 20-second timeout and 0.5-second polling, but still fails intermittently with `TimeoutException`.

This PR temporarily disables the test with `@pytest.mark.skip` to unblock CI/CD while we investigate and fix the underlying issue.

## Changes

- Add `@pytest.mark.skip` decorator to `test_mark_all_as_read_functionality`
- Reference issue #47 for tracking the fix

## Test Plan

- [x] Run `make lint-fix` - all checks pass
- [x] Run `make lint` - no errors
- [x] Verify tests run with skip in place

## Related

- Issue #47: Tracking investigation and fix for the flaky test
- PR #48: Fixes pre-existing type errors in `wafer_space/legal/tasks.py` (unrelated)

## Note

Pre-existing type errors in `wafer_space/legal/tasks.py` are not addressed in this PR and are being fixed separately in PR #48.

🤖 Generated with [Claude Code](https://claude.ai/code)