### PR TITLE
Fix SITE_URL type errors in legal tasks

### DIFF
--- a/wafer_space/legal/tasks.py
+++ b/wafer_space/legal/tasks.py
@@ -12,6 +12,22 @@ from django.utils.html import strip_tags
 logger = logging.getLogger(__name__)
 
 
+def _validate_site_url() -> str:
+    """Validate that SITE_URL is configured.
+
+    Returns:
+        str: The configured SITE_URL
+
+    Raises:
+        ValueError: If SITE_URL is not configured
+
+    """
+    if settings.SITE_URL is None:
+        msg = "SITE_URL must be configured in settings"
+        raise ValueError(msg)
+    return settings.SITE_URL
+
+
 @shared_task(bind=True, max_retries=3, default_retry_delay=300)
 def send_tos_update_email(self, notification_id: int) -> dict[str, str]:
     """Send TOS update notification email to a user.
@@ -39,12 +55,15 @@ def send_tos_update_email(self, notification_id: int) -> dict[str, str]:
                 "message": "Notification already sent",
             }
 
+        # Ensure SITE_URL is configured
+        site_url = _validate_site_url()
+
         # Prepare email context
         context = {
             "user": notification.user,
             "tos_version": notification.tos_version,
-            "tos_url": settings.SITE_URL + reverse("legal:tos_display"),
-            "accept_url": settings.SITE_URL + reverse("legal:tos_accept"),
+            "tos_url": site_url + reverse("legal:tos_display"),
+            "accept_url": site_url + reverse("legal:tos_accept"),
             "site_name": "wafer.space",
         }
 


### PR DESCRIPTION
## Summary

Fix pre-existing type errors in `wafer_space/legal/tasks.py` where `settings.SITE_URL` (typed as `str | None`) was being concatenated without null checking.

## Changes

- Add `_validate_site_url()` helper function to validate SITE_URL configuration
- Refactor email context preparation to use validated SITE_URL
- Ensures fail-fast behavior if SITE_URL is not configured in settings

## Type Errors Fixed

```
wafer_space/legal/tasks.py:46: error: Unsupported left operand type for + ("None")  [operator]
wafer_space/legal/tasks.py:46: note: Left operand is of type "str | None"
wafer_space/legal/tasks.py:47: error: Unsupported left operand type for + ("None")  [operator]
wafer_space/legal/tasks.py:47: note: Left operand is of type "str | None"
```

## Test Plan

- [x] Run `make lint-fix` - all checks pass
- [x] Run `make lint` - no errors
- [x] Run `make type-check` - no errors

🤖 Generated with [Claude Code](https://claude.ai/code)