### PR TITLE
Add mithis.com hostnames to staging ALLOWED_HOSTS

### DIFF
--- a/config/settings/stage.py
+++ b/config/settings/stage.py
@@ -13,6 +13,8 @@ ALLOWED_HOSTS = [
     "test-platform.wafer.space",
     "buddy.test-platform.wafer.space",
     "doc.test-platform.wafer.space",
+    "test-platform.buddy.mithis.com",
+    "test-platform.doc.mithis.com",
 ]
 SITE_URL = "https://test-platform.wafer.space"
 


### PR DESCRIPTION
## Summary

- Add `test-platform.buddy.mithis.com` to staging ALLOWED_HOSTS
- Add `test-platform.doc.mithis.com` to staging ALLOWED_HOSTS

## Test plan

- [ ] Deploy to staging and verify both hostnames resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended platform accessibility with support for access via two additional domain endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->