### PR TITLE
Add mithis.com hostnames for buddy and doc subdomains

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -11,6 +11,8 @@ from .base import env
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 ALLOWED_HOSTS = [
     "platform.wafer.space",
+    "platform-wafer-space.buddy.mithis.com",
+    "platform-wafer-space.doc.mithis.com",
 ]
 SITE_URL = "https://platform.wafer.space"
 

--- a/config/settings/stage.py
+++ b/config/settings/stage.py
@@ -15,6 +15,8 @@ ALLOWED_HOSTS = [
     "doc.test-platform.wafer.space",
     "test-platform.buddy.mithis.com",
     "test-platform.doc.mithis.com",
+    "test-platform-wafer-space.buddy.mithis.com",
+    "test-platform-wafer-space.doc.mithis.com",
 ]
 SITE_URL = "https://test-platform.wafer.space"
 


### PR DESCRIPTION
## Summary
- Add `test-platform-wafer-space.{buddy,doc}.mithis.com` to staging ALLOWED_HOSTS
- Add `platform-wafer-space.{buddy,doc}.mithis.com` to production ALLOWED_HOSTS

## Test plan
- [x] All tests pass (602 passed)
- [x] Lint and type-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated host configuration to support additional domain names in production and staging environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->