### PR TITLE
Standardize badge colors and components across the platform

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -121,6 +121,7 @@ THIRD_PARTY_APPS = [
 
 LOCAL_APPS = [
     "wafer_space.users",
+    "wafer_space.core",
     "wafer_space.legal",
     "wafer_space.notifications",
     "wafer_space.referrals",

--- a/docs/design/badge-system.md
+++ b/docs/design/badge-system.md
@@ -1,0 +1,157 @@
+# Badge System Design
+
+## What is a Badge?
+
+A badge is a visual indicator that communicates the state or status of an
+entity at a glance. Badges appear inline with content and use color, icons,
+and text to convey meaning quickly.
+
+## Scope
+
+This system standardizes badges for **general model state**: project status,
+file download status, hash verification, download attempts, and notification
+types.
+
+**Manufacturability check badges are out of scope.** Checks have their own
+badge tags in `wafer_space/projects/templatetags/precheck_tags.py`
+(`badge_check_status`, `badge_check_version`,
+`badge_check_status_and_version`), driven by
+`ManufacturabilityCheck._STATUS_METADATA`. Those tags add precheck container
+version indicators that this system deliberately does not model. Templates
+mix both systems side by side (see `_file_badges.html`).
+
+## Badge Anatomy
+
+```text
+┌─────────────────────────────────┐
+│ [icon] [text]                   │
+│  ↑       ↑                      │
+│  │       └── Label (required)   │
+│  └────────── Icon (optional)    │
+│                                 │
+│ Background color = badge type   │
+│ Text color = auto contrast      │
+└─────────────────────────────────┘
+```
+
+### Components
+
+| Component | Required | Description |
+|-----------|----------|-------------|
+| **Text** | Yes | Short label (1-3 words) describing the state |
+| **Background Color** | Yes | Determined by BadgeType - conveys semantic meaning |
+| **Icon** | No | Bootstrap icon, adds visual reinforcement |
+| **Spinner** | Auto | Shown automatically for PROCESSING type |
+
+## Badge Types (Semantic Meaning)
+
+| Type | Color | Bootstrap Class | Meaning |
+|------|-------|-----------------|---------|
+| SUCCESS | Green | `bg-success` | Completed successfully, verified, positive |
+| DANGER | Red | `bg-danger` | Failed, error, requires attention |
+| WARNING | Yellow | `bg-warning text-dark` | Uncertain, potential issue |
+| INFO | Light blue | `bg-info` | Informational, transitional |
+| PROCESSING | Blue | `bg-primary` + spinner | Active work in progress |
+| NEUTRAL | Gray | `bg-secondary` | Inactive, pending, default |
+
+## Badge Pipeline Model
+
+File badges represent stages in a processing pipeline. Each stage must
+complete successfully before the next stage's badge appears:
+
+```text
+Download → Hash Verification
+```
+
+Failure at any stage stops progression. The manufacturability check that
+follows the pipeline is rendered separately via `precheck_tags` (see Scope).
+
+## Usage in Templates
+
+```django
+{% load badges %}
+
+{# Render the download/hash pipeline badges for a file #}
+{% for badge in file.get_badges %}
+  {% render_badge badge %}
+{% endfor %}
+
+{# Render single badge #}
+{% render_badge project.get_status_badge %}
+```
+
+## Usage in Models
+
+```python
+from wafer_space.core.badges import BadgeInfo, BadgeType
+
+class MyModel(Model):
+    def get_badge(self) -> BadgeInfo:
+        if self.status == "success":
+            return BadgeInfo(
+                text="Completed",
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-check-circle",
+            )
+        return BadgeInfo(
+            text="Pending",
+            badge_type=BadgeType.NEUTRAL,
+        )
+```
+
+## State-to-Badge Mappings
+
+### Project.Status
+
+| Status | BadgeType | Text | Icon |
+|--------|-----------|------|------|
+| DRAFT | NEUTRAL | Draft | bi-pencil |
+| SUBMITTED | INFO | Submitted | bi-send |
+| CHECKING | PROCESSING | Checking | (spinner) |
+| MANUFACTURABLE | SUCCESS | Manufacturable | bi-check-circle |
+| NOT_MANUFACTURABLE | DANGER | Not Manufacturable | bi-x-circle |
+| ASSIGNED_TO_SHUTTLE | INFO | Assigned to Shuttle | bi-truck |
+| IN_PRODUCTION | PROCESSING | In Production | (spinner) |
+| COMPLETED | SUCCESS | Completed | bi-check-circle-fill |
+| CANCELLED | NEUTRAL | Cancelled | bi-x-circle |
+
+### ProjectFile.DownloadStatus
+
+| Status | BadgeType | Text | Icon |
+|--------|-----------|------|------|
+| PENDING | NEUTRAL | Download Pending | bi-clock |
+| QUEUED | NEUTRAL | Queued | bi-hourglass-split |
+| DOWNLOADING | PROCESSING | Downloading | (spinner) |
+| COMPLETED | SUCCESS | Downloaded | bi-check-circle |
+| FAILED | DANGER | Download Failed | bi-exclamation-triangle |
+
+### Hash Verification
+
+| State | BadgeType | Text | Icon |
+|-------|-----------|------|------|
+| Verified | SUCCESS | Hash Verified | bi-shield-check |
+| Mismatch | DANGER | Hash Mismatch | bi-shield-x |
+| Unverified | WARNING | Hash Unverified | bi-shield-exclamation |
+
+### DownloadAttempt.Status
+
+| Status | BadgeType | Text | Icon |
+|--------|-----------|------|------|
+| PENDING | NEUTRAL | Pending | bi-clock |
+| DOWNLOADING | PROCESSING | Downloading | (spinner) |
+| COMPLETED | SUCCESS | Completed | bi-check-circle |
+| FAILED | DANGER | Failed | bi-exclamation-triangle |
+
+### Notification.Type
+
+| Type | BadgeType | Icon |
+|------|-----------|------|
+| DOWNLOAD_COMPLETE | SUCCESS | bi-check-circle |
+| DOWNLOAD_FAILED | DANGER | bi-exclamation-triangle |
+| CHECKSUM_VERIFIED | SUCCESS | bi-shield-check |
+| CHECKSUM_MISMATCH | WARNING | bi-shield-x |
+| MANUFACTURING_COMPLETE | SUCCESS | bi-box-seam |
+| TOS_UPDATE | INFO | bi-file-text |
+
+Unknown notification types fall back to a NEUTRAL badge showing the raw type
+value, so new types degrade gracefully until a mapping is added.

--- a/wafer_space/core/badges.py
+++ b/wafer_space/core/badges.py
@@ -1,0 +1,98 @@
+"""Badge system for consistent status display across the platform.
+
+This module provides a unified way to represent status badges with consistent
+colors, icons, and behavior.
+
+Scope: badges for general model state (project status, download status, hash
+verification, notification types). Manufacturability check badges are NOT
+rendered through this system - they use the check-specific tags in
+``wafer_space/projects/templatetags/precheck_tags.py``, which add container
+version indicators this system does not model.
+
+Badge Types (semantic meaning):
+- SUCCESS: Green - completed successfully, verified, positive outcome
+- DANGER: Red - failed, error, requires attention
+- WARNING: Yellow - uncertain state, potential issue
+- INFO: Light blue - informational, transitional state
+- PROCESSING: Blue with spinner - active work in progress
+- NEUTRAL: Gray - inactive, pending, default state
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from django.template.loader import render_to_string
+
+
+class BadgeType(Enum):
+    """Semantic badge types that map to Bootstrap CSS classes.
+
+    These represent the visual meaning of a badge, not the specific status.
+    Multiple statuses can map to the same badge type.
+    """
+
+    SUCCESS = "success"
+    DANGER = "danger"
+    WARNING = "warning"
+    INFO = "info"
+    PROCESSING = "processing"
+    NEUTRAL = "neutral"
+
+
+# BadgeType -> Bootstrap CSS class mapping
+BADGE_CSS_MAP: dict[BadgeType, str] = {
+    BadgeType.SUCCESS: "bg-success",
+    BadgeType.DANGER: "bg-danger",
+    BadgeType.WARNING: "bg-warning text-dark",
+    BadgeType.INFO: "bg-info",
+    BadgeType.PROCESSING: "bg-primary",
+    BadgeType.NEUTRAL: "bg-secondary",
+}
+
+
+@dataclass(frozen=True)
+class BadgeInfo:
+    """Immutable badge configuration returned by models.
+
+    Attributes:
+        text: The display text for the badge (1-3 words).
+        badge_type: The semantic type determining color and style.
+        icon: Optional Bootstrap icon class (e.g., "bi-check-circle").
+    """
+
+    text: str
+    badge_type: BadgeType
+    icon: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Convert to dictionary for JSON serialization.
+
+        Used for JavaScript real-time status updates.
+        """
+        return {
+            "text": self.text,
+            "badge_type": self.badge_type.value,
+            "icon": self.icon,
+        }
+
+
+def render_badge_html(badge: BadgeInfo) -> str:
+    """Render a BadgeInfo to HTML string for AJAX responses.
+
+    Args:
+        badge: BadgeInfo instance to render.
+
+    Returns:
+        HTML string suitable for inserting into DOM.
+    """
+    return render_to_string(
+        "core/_badge.html",
+        {
+            "text": badge.text,
+            "css_class": BADGE_CSS_MAP[badge.badge_type],
+            "icon": badge.icon,
+            "is_processing": badge.badge_type == BadgeType.PROCESSING,
+        },
+    )

--- a/wafer_space/core/templatetags/__init__.py
+++ b/wafer_space/core/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Template tags for core utilities."""

--- a/wafer_space/core/templatetags/badges.py
+++ b/wafer_space/core/templatetags/badges.py
@@ -1,0 +1,33 @@
+"""Template tags for rendering badges consistently."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django import template
+
+from wafer_space.core.badges import BADGE_CSS_MAP
+from wafer_space.core.badges import BadgeType
+
+if TYPE_CHECKING:
+    from wafer_space.core.badges import BadgeInfo
+
+register = template.Library()
+
+
+@register.inclusion_tag("core/_badge.html")
+def render_badge(badge: BadgeInfo) -> dict[str, str | bool | None]:
+    """Render a badge with consistent styling.
+
+    Args:
+        badge: BadgeInfo instance with text, type, and optional icon.
+
+    Returns:
+        Context dict for the badge template.
+    """
+    return {
+        "text": badge.text,
+        "css_class": BADGE_CSS_MAP[badge.badge_type],
+        "icon": badge.icon,
+        "is_processing": badge.badge_type == BadgeType.PROCESSING,
+    }

--- a/wafer_space/core/templatetags/badges.py
+++ b/wafer_space/core/templatetags/badges.py
@@ -8,9 +8,11 @@ from django import template
 
 from wafer_space.core.badges import BADGE_CSS_MAP
 from wafer_space.core.badges import BadgeType
+from wafer_space.core.badges import render_badge_html
 
 if TYPE_CHECKING:
     from wafer_space.core.badges import BadgeInfo
+    from wafer_space.projects.models import ProjectFile
 
 register = template.Library()
 
@@ -31,3 +33,24 @@ def render_badge(badge: BadgeInfo) -> dict[str, str | bool | None]:
         "icon": badge.icon,
         "is_processing": badge.badge_type == BadgeType.PROCESSING,
     }
+
+
+@register.simple_tag
+def render_inline_hash_badge(file: ProjectFile, hash_type: str) -> str:
+    """Render inline hash verification badge for a specific hash type.
+
+    Used in templates to show Verified/Mismatch next to each hash value.
+    Django's render_to_string returns SafeString, so output is already safe.
+
+    Args:
+        file: ProjectFile instance
+        hash_type: One of 'md5', 'sha1', 'sha256'
+
+    Returns:
+        HTML string for the badge, or empty string if no expected hash.
+    """
+    badge = file.get_inline_hash_badge(hash_type)
+    if badge:
+        # render_badge_html uses render_to_string which returns SafeString
+        return render_badge_html(badge)
+    return ""

--- a/wafer_space/core/tests/test_badges.py
+++ b/wafer_space/core/tests/test_badges.py
@@ -1,0 +1,111 @@
+"""Tests for the badge system."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from wafer_space.core.badges import BadgeInfo
+from wafer_space.core.badges import BadgeType
+from wafer_space.core.badges import render_badge_html
+
+
+class TestBadgeType:
+    """Tests for BadgeType enum."""
+
+    def test_badge_type_has_success(self) -> None:
+        assert BadgeType.SUCCESS.value == "success"
+
+    def test_badge_type_has_danger(self) -> None:
+        assert BadgeType.DANGER.value == "danger"
+
+    def test_badge_type_has_warning(self) -> None:
+        assert BadgeType.WARNING.value == "warning"
+
+    def test_badge_type_has_info(self) -> None:
+        assert BadgeType.INFO.value == "info"
+
+    def test_badge_type_has_processing(self) -> None:
+        assert BadgeType.PROCESSING.value == "processing"
+
+    def test_badge_type_has_neutral(self) -> None:
+        assert BadgeType.NEUTRAL.value == "neutral"
+
+
+class TestBadgeInfo:
+    """Tests for BadgeInfo dataclass."""
+
+    def test_badge_info_creation(self) -> None:
+        badge = BadgeInfo(text="Test", badge_type=BadgeType.SUCCESS)
+        assert badge.text == "Test"
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.icon is None
+
+    def test_badge_info_with_icon(self) -> None:
+        badge = BadgeInfo(
+            text="Downloaded",
+            badge_type=BadgeType.SUCCESS,
+            icon="bi-check-circle",
+        )
+        assert badge.icon == "bi-check-circle"
+
+    def test_badge_info_is_frozen(self) -> None:
+        badge = BadgeInfo(text="Test", badge_type=BadgeType.SUCCESS)
+        # Attribute name held in a variable so the frozen-dataclass
+        # assignment is exercised at runtime rather than rejected by mypy
+        attr_name = "text"
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(badge, attr_name, "Changed")
+
+    def test_badge_info_to_dict(self) -> None:
+        badge = BadgeInfo(
+            text="Downloaded",
+            badge_type=BadgeType.SUCCESS,
+            icon="bi-check-circle",
+        )
+        result = badge.to_dict()
+        assert result == {
+            "text": "Downloaded",
+            "badge_type": "success",
+            "icon": "bi-check-circle",
+        }
+
+    def test_badge_info_to_dict_without_icon(self) -> None:
+        badge = BadgeInfo(text="Pending", badge_type=BadgeType.NEUTRAL)
+        result = badge.to_dict()
+        assert result == {
+            "text": "Pending",
+            "badge_type": "neutral",
+            "icon": None,
+        }
+
+
+class TestRenderBadgeHtml:
+    """Tests for render_badge_html helper function."""
+
+    def test_render_badge_html_returns_html_string(self) -> None:
+        badge = BadgeInfo(
+            text="Downloaded",
+            badge_type=BadgeType.SUCCESS,
+            icon="bi-check-circle",
+        )
+        result = render_badge_html(badge)
+
+        assert '<span class="badge bg-success">' in result
+        assert "Downloaded" in result
+        assert "bi-check-circle" in result
+
+    def test_render_badge_html_processing_has_spinner(self) -> None:
+        badge = BadgeInfo(text="Downloading", badge_type=BadgeType.PROCESSING)
+        result = render_badge_html(badge)
+
+        assert "spinner-border" in result
+        assert "Downloading" in result
+
+    def test_render_badge_html_warning_has_text_dark(self) -> None:
+        badge = BadgeInfo(text="Warning", badge_type=BadgeType.WARNING)
+        result = render_badge_html(badge)
+
+        assert "bg-warning" in result
+        assert "text-dark" in result

--- a/wafer_space/core/tests/test_templatetags.py
+++ b/wafer_space/core/tests/test_templatetags.py
@@ -1,0 +1,67 @@
+"""Tests for badge template tags."""
+
+from __future__ import annotations
+
+import pytest
+from django.template import Context
+from django.template import Template
+
+from wafer_space.core.badges import BadgeInfo
+from wafer_space.core.badges import BadgeType
+
+
+class TestRenderBadgeTag:
+    """Tests for the render_badge template tag."""
+
+    @pytest.mark.django_db
+    def test_render_badge_success(self) -> None:
+        template = Template("{% load badges %}{% render_badge badge %}")
+        badge = BadgeInfo(text="Downloaded", badge_type=BadgeType.SUCCESS)
+        context = Context({"badge": badge})
+        result = template.render(context)
+
+        assert "bg-success" in result
+        assert "Downloaded" in result
+
+    @pytest.mark.django_db
+    def test_render_badge_danger(self) -> None:
+        template = Template("{% load badges %}{% render_badge badge %}")
+        badge = BadgeInfo(text="Failed", badge_type=BadgeType.DANGER)
+        context = Context({"badge": badge})
+        result = template.render(context)
+
+        assert "bg-danger" in result
+        assert "Failed" in result
+
+    @pytest.mark.django_db
+    def test_render_badge_with_icon(self) -> None:
+        template = Template("{% load badges %}{% render_badge badge %}")
+        badge = BadgeInfo(
+            text="Verified",
+            badge_type=BadgeType.SUCCESS,
+            icon="bi-shield-check",
+        )
+        context = Context({"badge": badge})
+        result = template.render(context)
+
+        assert "bi-shield-check" in result
+
+    @pytest.mark.django_db
+    def test_render_badge_processing_has_spinner(self) -> None:
+        template = Template("{% load badges %}{% render_badge badge %}")
+        badge = BadgeInfo(text="Checking...", badge_type=BadgeType.PROCESSING)
+        context = Context({"badge": badge})
+        result = template.render(context)
+
+        assert "spinner-border" in result
+        assert "bg-primary" in result
+
+    @pytest.mark.django_db
+    def test_render_badge_warning_has_text_dark(self) -> None:
+        template = Template("{% load badges %}{% render_badge badge %}")
+        badge = BadgeInfo(text="Unverified", badge_type=BadgeType.WARNING)
+        context = Context({"badge": badge})
+        result = template.render(context)
+
+        assert "bg-warning" in result
+        assert "text-dark" in result

--- a/wafer_space/notifications/models.py
+++ b/wafer_space/notifications/models.py
@@ -1,10 +1,15 @@
 """Models for notifications system."""
 
+from __future__ import annotations
+
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils import timezone
+
+from wafer_space.core.badges import BadgeInfo
+from wafer_space.core.badges import BadgeType
 
 
 class Notification(models.Model):
@@ -67,3 +72,53 @@ class Notification(models.Model):
             self.is_read = True
             self.read_at = timezone.now()
             self.save(update_fields=["is_read", "read_at"])
+
+    def get_type_badge(self) -> BadgeInfo:
+        """Return badge info for notification type.
+
+        Returns:
+            BadgeInfo with appropriate badge type, text, and icon.
+        """
+        # Map notification types to badge configurations
+        badge_map: dict[str, BadgeInfo] = {
+            self.Type.DOWNLOAD_COMPLETE.value: BadgeInfo(
+                text=self.Type.DOWNLOAD_COMPLETE.label,
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-check-circle",
+            ),
+            self.Type.DOWNLOAD_FAILED.value: BadgeInfo(
+                text=self.Type.DOWNLOAD_FAILED.label,
+                badge_type=BadgeType.DANGER,
+                icon="bi-exclamation-triangle",
+            ),
+            self.Type.CHECKSUM_VERIFIED.value: BadgeInfo(
+                text=self.Type.CHECKSUM_VERIFIED.label,
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-shield-check",
+            ),
+            self.Type.CHECKSUM_MISMATCH.value: BadgeInfo(
+                text=self.Type.CHECKSUM_MISMATCH.label,
+                badge_type=BadgeType.WARNING,
+                icon="bi-shield-x",
+            ),
+            self.Type.MANUFACTURING_COMPLETE.value: BadgeInfo(
+                text=self.Type.MANUFACTURING_COMPLETE.label,
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-box-seam",
+            ),
+            self.Type.TOS_UPDATE.value: BadgeInfo(
+                text=self.Type.TOS_UPDATE.label,
+                badge_type=BadgeType.INFO,
+                icon="bi-file-text",
+            ),
+        }
+
+        # Get badge for current type, or return neutral badge for unknown types
+        return badge_map.get(
+            self.notification_type,
+            BadgeInfo(
+                text=self.notification_type,
+                badge_type=BadgeType.NEUTRAL,
+                icon=None,
+            ),
+        )

--- a/wafer_space/notifications/templates/notifications/notification_list.html
+++ b/wafer_space/notifications/templates/notifications/notification_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static %}
+{% load static badges %}
 
 {% block title %}
   Notifications
@@ -51,11 +51,7 @@
                 </div>
                 <p class="mb-1">{{ notification.message }}</p>
                 <div class="d-flex justify-content-between align-items-center">
-                  <small>
-                    <span class="badge {% if notification.notification_type == 'download_complete' %}bg-success{% elif notification.notification_type == 'download_failed' %}bg-danger{% elif notification.notification_type == 'checksum_verified' %}bg-success{% elif notification.notification_type == 'checksum_mismatch' %}bg-warning{% else %}bg-secondary{% endif %}">
-                      {{ notification.get_notification_type_display }}
-                    </span>
-                  </small>
+                  <small>{% render_badge notification.get_type_badge %}</small>
                   {% if not notification.is_read %}
                     <small class="text-primary">
                       <i class="bi bi-circle-fill"></i> New

--- a/wafer_space/notifications/tests/test_badges.py
+++ b/wafer_space/notifications/tests/test_badges.py
@@ -1,0 +1,121 @@
+"""Tests for badge methods on notification models."""
+
+from __future__ import annotations
+
+import pytest
+
+from wafer_space.core.badges import BadgeType
+from wafer_space.notifications.models import Notification
+from wafer_space.users.models import User
+
+
+class TestNotificationTypeBadge:
+    """Tests for Notification.get_type_badge() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        # No password needed - these tests never authenticate
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+        )
+
+    def test_download_complete_returns_success_badge(self) -> None:
+        notification = Notification.objects.create(
+            user=self.user,
+            notification_type=Notification.Type.DOWNLOAD_COMPLETE,
+            title="Download Complete",
+            message="Your file download is complete.",
+        )
+        badge = notification.get_type_badge()
+
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.text == "Download Complete"
+        assert badge.icon == "bi-check-circle"
+
+    def test_download_failed_returns_danger_badge(self) -> None:
+        notification = Notification.objects.create(
+            user=self.user,
+            notification_type=Notification.Type.DOWNLOAD_FAILED,
+            title="Download Failed",
+            message="Your file download has failed.",
+        )
+        badge = notification.get_type_badge()
+
+        assert badge.badge_type == BadgeType.DANGER
+        assert badge.text == "Download Failed"
+        assert badge.icon == "bi-exclamation-triangle"
+
+    def test_checksum_verified_returns_success_badge(self) -> None:
+        notification = Notification.objects.create(
+            user=self.user,
+            notification_type=Notification.Type.CHECKSUM_VERIFIED,
+            title="Checksum Verified",
+            message="File checksum has been verified.",
+        )
+        badge = notification.get_type_badge()
+
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.text == "Checksum Verified"
+        assert badge.icon == "bi-shield-check"
+
+    def test_checksum_mismatch_returns_warning_badge(self) -> None:
+        notification = Notification.objects.create(
+            user=self.user,
+            notification_type=Notification.Type.CHECKSUM_MISMATCH,
+            title="Checksum Mismatch",
+            message="File checksum does not match expected value.",
+        )
+        badge = notification.get_type_badge()
+
+        assert badge.badge_type == BadgeType.WARNING
+        assert badge.text == "Checksum Mismatch"
+        assert badge.icon == "bi-shield-x"
+
+    def test_manufacturing_complete_returns_success_badge(self) -> None:
+        notification = Notification.objects.create(
+            user=self.user,
+            notification_type=Notification.Type.MANUFACTURING_COMPLETE,
+            title="Manufacturing Complete",
+            message="Your manufacturing order is complete.",
+        )
+        badge = notification.get_type_badge()
+
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.text == "Manufacturing Complete"
+        assert badge.icon == "bi-box-seam"
+
+    def test_tos_update_returns_info_badge(self) -> None:
+        notification = Notification.objects.create(
+            user=self.user,
+            notification_type=Notification.Type.TOS_UPDATE,
+            title="Terms of Service Update",
+            message="Our terms of service have been updated.",
+        )
+        badge = notification.get_type_badge()
+
+        assert badge.badge_type == BadgeType.INFO
+        assert badge.text == "Terms of Service Update"
+        assert badge.icon == "bi-file-text"
+
+    def test_unknown_type_returns_neutral_badge_with_display_name(self) -> None:
+        # Create notification with a valid type first
+        notification = Notification.objects.create(
+            user=self.user,
+            notification_type=Notification.Type.DOWNLOAD_COMPLETE,
+            title="Test",
+            message="Test message",
+        )
+
+        # Manually override the notification_type to an invalid value
+        # This simulates what would happen if a new type was added but
+        # get_type_badge() wasn't updated
+        notification.notification_type = "unknown_type"
+        notification.save()
+
+        badge = notification.get_type_badge()
+
+        assert badge.badge_type == BadgeType.NEUTRAL
+        assert badge.text == "unknown_type"
+        assert badge.icon is None

--- a/wafer_space/projects/models.py
+++ b/wafer_space/projects/models.py
@@ -552,6 +552,21 @@ class Project(models.Model):
         }
         return status_badges[self.status]
 
+    def get_badges(self) -> list[BadgeInfo]:
+        """Return download/hash pipeline badges for this project's active file.
+
+        Project badges delegate to the active file since that represents
+        the current state of the project.
+
+        Returns:
+            List of BadgeInfo from active file, or empty list.
+        """
+        try:
+            active_file = self.files.get(is_active=True)
+        except ProjectFile.DoesNotExist:
+            return []
+        return active_file.get_badges()
+
     def can_submit(self) -> tuple[bool, str]:
         """Check if project can be submitted.
 

--- a/wafer_space/projects/models.py
+++ b/wafer_space/projects/models.py
@@ -17,6 +17,8 @@ from django.utils import timezone
 from django.utils.formats import date_format
 from simple_history.models import HistoricalRecords
 
+from wafer_space.core.badges import BadgeInfo
+from wafer_space.core.badges import BadgeType
 from wafer_space.core.enums import SlotSize
 from wafer_space.projects.exceptions import InvalidStateTransitionError
 from wafer_space.projects.storage import ProjectFileStorage
@@ -496,6 +498,59 @@ class Project(models.Model):
     def is_other_license(self) -> bool:
         """Check if project uses 'other' (custom SPDX) license."""
         return self.license_type == LicenseType.OTHER
+
+    def get_status_badge(self) -> BadgeInfo:
+        """Return badge representing current project status.
+
+        Returns:
+            BadgeInfo with appropriate type, text, and icon.
+        """
+        status_badges: dict[str, BadgeInfo] = {
+            self.Status.DRAFT.value: BadgeInfo(
+                text="Draft",
+                badge_type=BadgeType.NEUTRAL,
+                icon="bi-pencil",
+            ),
+            self.Status.SUBMITTED.value: BadgeInfo(
+                text="Submitted",
+                badge_type=BadgeType.INFO,
+                icon="bi-send",
+            ),
+            self.Status.CHECKING.value: BadgeInfo(
+                text="Checking",
+                badge_type=BadgeType.PROCESSING,
+            ),
+            self.Status.MANUFACTURABLE.value: BadgeInfo(
+                text="Manufacturable",
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-check-circle",
+            ),
+            self.Status.NOT_MANUFACTURABLE.value: BadgeInfo(
+                text="Not Manufacturable",
+                badge_type=BadgeType.DANGER,
+                icon="bi-x-circle",
+            ),
+            self.Status.ASSIGNED_TO_SHUTTLE.value: BadgeInfo(
+                text="Assigned to Shuttle",
+                badge_type=BadgeType.INFO,
+                icon="bi-truck",
+            ),
+            self.Status.IN_PRODUCTION.value: BadgeInfo(
+                text="In Production",
+                badge_type=BadgeType.PROCESSING,
+            ),
+            self.Status.COMPLETED.value: BadgeInfo(
+                text="Completed",
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-check-circle-fill",
+            ),
+            self.Status.CANCELLED.value: BadgeInfo(
+                text="Cancelled",
+                badge_type=BadgeType.NEUTRAL,
+                icon="bi-x-circle",
+            ),
+        }
+        return status_badges[self.status]
 
     def can_submit(self) -> tuple[bool, str]:
         """Check if project can be submitted.

--- a/wafer_space/projects/models.py
+++ b/wafer_space/projects/models.py
@@ -1374,6 +1374,35 @@ class DownloadAttempt(models.Model):
             speed_bytes_per_sec /= bytes_per_unit
         return f"{speed_bytes_per_sec:.1f} TB/s"
 
+    def get_badge(self) -> BadgeInfo:
+        """Return badge representing current download attempt status.
+
+        Returns:
+            BadgeInfo with appropriate type, text, and icon.
+        """
+        status_badges: dict[str, BadgeInfo] = {
+            self.Status.PENDING.value: BadgeInfo(
+                text="Pending",
+                badge_type=BadgeType.NEUTRAL,
+                icon="bi-clock",
+            ),
+            self.Status.DOWNLOADING.value: BadgeInfo(
+                text="Downloading",
+                badge_type=BadgeType.PROCESSING,
+            ),
+            self.Status.COMPLETED.value: BadgeInfo(
+                text="Completed",
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-check-circle",
+            ),
+            self.Status.FAILED.value: BadgeInfo(
+                text="Failed",
+                badge_type=BadgeType.DANGER,
+                icon="bi-exclamation-triangle",
+            ),
+        }
+        return status_badges[self.status]
+
 
 class ProjectFileChunk(models.Model):
     """Track individual chunk downloads for performance analysis and resume capability.

--- a/wafer_space/projects/models.py
+++ b/wafer_space/projects/models.py
@@ -1159,6 +1159,124 @@ class ProjectFile(models.Model):
             or self.expected_hash_sha256
         )
 
+    def get_download_badge(self) -> BadgeInfo:
+        """Return badge for current download status."""
+        if self.download_status == self.DownloadStatus.PENDING:
+            return BadgeInfo(
+                text="Download Pending",
+                badge_type=BadgeType.NEUTRAL,
+                icon="bi-clock",
+            )
+        if self.download_status == self.DownloadStatus.QUEUED:
+            return BadgeInfo(
+                text="Queued",
+                badge_type=BadgeType.NEUTRAL,
+                icon="bi-hourglass-split",
+            )
+        if self.download_status == self.DownloadStatus.DOWNLOADING:
+            return BadgeInfo(
+                text="Downloading",
+                badge_type=BadgeType.PROCESSING,
+            )
+        if self.download_status == self.DownloadStatus.COMPLETED:
+            return BadgeInfo(
+                text="Downloaded",
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-check-circle",
+            )
+        # FAILED
+        return BadgeInfo(
+            text="Download Failed",
+            badge_type=BadgeType.DANGER,
+            icon="bi-exclamation-triangle",
+        )
+
+    def get_hash_badge(self) -> BadgeInfo | None:
+        """Return badge for hash verification status.
+
+        Returns:
+            BadgeInfo if hash verification applicable, None otherwise.
+        """
+        if not self.has_expected_hash:
+            return None
+
+        if self.hash_verified:
+            return BadgeInfo(
+                text="Hash Verified",
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-shield-check",
+            )
+        if self.has_hash_mismatch:
+            return BadgeInfo(
+                text="Hash Mismatch",
+                badge_type=BadgeType.DANGER,
+                icon="bi-shield-x",
+            )
+        # Has expected hash but not yet verified
+        return BadgeInfo(
+            text="Hash Unverified",
+            badge_type=BadgeType.WARNING,
+            icon="bi-shield-exclamation",
+        )
+
+    def get_inline_hash_badge(self, hash_type: str) -> BadgeInfo | None:
+        """Return inline badge for a specific hash verification.
+
+        Used in templates to show Verified/Mismatch next to each hash value.
+
+        Args:
+            hash_type: One of 'md5', 'sha1', 'sha256'
+
+        Returns:
+            BadgeInfo if expected hash exists, None otherwise.
+        """
+        hash_field = f"hash_{hash_type}"
+        expected_field = f"expected_hash_{hash_type}"
+
+        actual = getattr(self, hash_field, None)
+        expected = getattr(self, expected_field, None)
+
+        if not expected:
+            return None
+
+        if actual and actual.lower() == expected.lower():
+            return BadgeInfo(
+                text="Verified",
+                badge_type=BadgeType.SUCCESS,
+                icon="bi-check-circle",
+            )
+        return BadgeInfo(
+            text="Mismatch",
+            badge_type=BadgeType.DANGER,
+            icon="bi-x-circle",
+        )
+
+    def get_badges(self) -> list[BadgeInfo]:
+        """Return download/hash pipeline badges for this file.
+
+        Badges represent stages: Download -> Hash. Failure at any stage
+        stops the pipeline. The manufacturability check that follows the
+        pipeline is rendered separately via the precheck_tags template tags,
+        which add container version indicators (see docs/design/badge-system.md).
+
+        Returns:
+            List of BadgeInfo objects in pipeline order.
+        """
+        badges: list[BadgeInfo] = []
+
+        # Stage 1: Download (always shown)
+        badges.append(self.get_download_badge())
+        if self.download_status == self.DownloadStatus.FAILED:
+            return badges  # Pipeline stops
+
+        # Stage 2: Hash verification (only if download completed)
+        if self.download_status == self.DownloadStatus.COMPLETED:
+            hash_badge = self.get_hash_badge()
+            if hash_badge:
+                badges.append(hash_badge)
+
+        return badges
+
     @property
     def latest_manufacturability_check(self) -> "ManufacturabilityCheck | None":
         """Get the most recent manufacturability check.

--- a/wafer_space/projects/tests/test_badges.py
+++ b/wafer_space/projects/tests/test_badges.py
@@ -548,3 +548,47 @@ class TestProjectFileGetBadges:
         expected_badges = 2
         assert len(badges) == expected_badges
         assert badges[1].badge_type == BadgeType.DANGER
+
+
+class TestProjectGetBadges:
+    """Tests for Project.get_badges() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        # No password needed - these tests never authenticate
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+        )
+        self.project = Project.objects.create(
+            user=self.user,
+            name="Test Project",
+            description="Test project",
+        )
+
+    def test_project_with_active_file_delegates_to_file(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            is_active=True,
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="completed",
+        )
+
+        badges = self.project.get_badges()
+
+        # Should have at least the download badge from the file
+        assert len(badges) >= 1
+        assert badges[0].badge_type == BadgeType.SUCCESS
+
+    def test_project_without_active_file_returns_empty(self) -> None:
+        # Create a project with no files
+        badges = self.project.get_badges()
+
+        assert badges == []

--- a/wafer_space/projects/tests/test_badges.py
+++ b/wafer_space/projects/tests/test_badges.py
@@ -193,3 +193,358 @@ class TestDownloadAttemptBadge:
         assert badge.badge_type == BadgeType.DANGER
         assert badge.text == "Failed"
         assert badge.icon == "bi-exclamation-triangle"
+
+
+class TestProjectFileDownloadBadge:
+    """Tests for ProjectFile.get_download_badge() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        # No password needed - these tests never authenticate
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+        )
+        self.project = Project.objects.create(
+            user=self.user,
+            name="Test Project",
+            description="Test project",
+        )
+
+    def test_pending_returns_neutral_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+        )
+        # No download attempts = PENDING status
+        badge = file.get_download_badge()
+
+        assert badge.badge_type == BadgeType.NEUTRAL
+        assert "Pending" in badge.text
+
+    def test_queued_returns_neutral_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            download_task_id="task-123",
+        )
+        # No download attempts but has task_id = QUEUED status
+        badge = file.get_download_badge()
+
+        assert badge.badge_type == BadgeType.NEUTRAL
+
+    def test_downloading_returns_processing_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="downloading",
+        )
+        badge = file.get_download_badge()
+
+        assert badge.badge_type == BadgeType.PROCESSING
+
+    def test_completed_returns_success_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="completed",
+        )
+        badge = file.get_download_badge()
+
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.icon == "bi-check-circle"
+
+    def test_failed_returns_danger_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="failed",
+        )
+        badge = file.get_download_badge()
+
+        assert badge.badge_type == BadgeType.DANGER
+
+
+class TestProjectFileHashBadge:
+    """Tests for ProjectFile.get_hash_badge() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        # No password needed - these tests never authenticate
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+        )
+        self.project = Project.objects.create(
+            user=self.user,
+            name="Test Project",
+            description="Test project",
+        )
+
+    def test_verified_returns_success_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            expected_hash_md5="abc123",
+            hash_md5="abc123",
+            hash_verified=True,
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="completed",
+        )
+        badge = file.get_hash_badge()
+
+        assert badge is not None
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.icon == "bi-shield-check"
+
+    def test_mismatch_returns_danger_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            expected_hash_md5="abc123",
+            hash_md5="def456",
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="completed",
+        )
+        badge = file.get_hash_badge()
+
+        assert badge is not None
+        assert badge.badge_type == BadgeType.DANGER
+        assert badge.icon == "bi-shield-x"
+
+    def test_no_expected_hash_returns_none(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            hash_md5="abc123",
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="completed",
+        )
+        badge = file.get_hash_badge()
+
+        assert badge is None
+
+
+class TestProjectFileInlineHashBadge:
+    """Tests for ProjectFile.get_inline_hash_badge() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        # No password needed - these tests never authenticate
+        self.user = User.objects.create_user(
+            username="testuser_inline_hash",
+            email="inline_hash@example.com",
+        )
+        self.project = Project.objects.create(
+            user=self.user,
+            name="Test Project Inline Hash",
+            description="Test project",
+        )
+
+    def test_md5_verified_returns_success_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            hash_md5="abc123def456",
+            expected_hash_md5="ABC123DEF456",  # Case insensitive match
+        )
+        badge = file.get_inline_hash_badge("md5")
+
+        assert badge is not None
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.text == "Verified"
+        assert badge.icon == "bi-check-circle"
+
+    def test_md5_mismatch_returns_danger_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            hash_md5="abc123",
+            expected_hash_md5="different",
+        )
+        badge = file.get_inline_hash_badge("md5")
+
+        assert badge is not None
+        assert badge.badge_type == BadgeType.DANGER
+        assert badge.text == "Mismatch"
+        assert badge.icon == "bi-x-circle"
+
+    def test_sha1_verified_returns_success_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            hash_sha1="abc123",
+            expected_hash_sha1="abc123",
+        )
+        badge = file.get_inline_hash_badge("sha1")
+
+        assert badge is not None
+        assert badge.badge_type == BadgeType.SUCCESS
+
+    def test_sha256_mismatch_returns_danger_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            hash_sha256="abc123",
+            expected_hash_sha256="xyz789",
+        )
+        badge = file.get_inline_hash_badge("sha256")
+
+        assert badge is not None
+        assert badge.badge_type == BadgeType.DANGER
+
+    def test_no_expected_hash_returns_none(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            hash_md5="abc123",
+            # No expected_hash_md5 set
+        )
+        badge = file.get_inline_hash_badge("md5")
+
+        assert badge is None
+
+    def test_no_actual_hash_returns_mismatch(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            expected_hash_md5="abc123",
+            # No hash_md5 set (download not complete)
+        )
+        badge = file.get_inline_hash_badge("md5")
+
+        assert badge is not None
+        assert badge.badge_type == BadgeType.DANGER
+        assert badge.text == "Mismatch"
+
+
+class TestProjectFileGetBadges:
+    """Tests for ProjectFile.get_badges() pipeline method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        # No password needed - these tests never authenticate
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+        )
+        self.project = Project.objects.create(
+            user=self.user,
+            name="Test Project",
+            description="Test project",
+        )
+
+    def test_failed_download_stops_pipeline(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="failed",
+        )
+        badges = file.get_badges()
+
+        # Only the download badge - the hash stage never runs
+        assert len(badges) == 1
+        assert badges[0].badge_type == BadgeType.DANGER
+
+    def test_completed_download_includes_hash_badge(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            expected_hash_md5="abc123",
+            hash_md5="abc123",
+            hash_verified=True,
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="completed",
+        )
+        badges = file.get_badges()
+
+        # Download + Hash badges
+        expected_badges = 2
+        assert len(badges) == expected_badges
+        badge_types = [b.badge_type for b in badges]
+        assert BadgeType.SUCCESS in badge_types
+
+    def test_hash_mismatch_included_in_pipeline(self) -> None:
+        file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+            expected_hash_md5="abc123",
+            hash_md5="def456",
+        )
+        DownloadAttempt.objects.create(
+            project_file=file,
+            attempt_number=1,
+            status="completed",
+        )
+        badges = file.get_badges()
+
+        # Download + Hash mismatch badges
+        expected_badges = 2
+        assert len(badges) == expected_badges
+        assert badges[1].badge_type == BadgeType.DANGER

--- a/wafer_space/projects/tests/test_badges.py
+++ b/wafer_space/projects/tests/test_badges.py
@@ -1,0 +1,123 @@
+"""Tests for badge methods on project models."""
+
+from __future__ import annotations
+
+import pytest
+
+from wafer_space.core.badges import BadgeType
+from wafer_space.projects.models import Project
+from wafer_space.users.models import User
+
+from .constants import TEST_PASSWORD
+
+
+class TestProjectStatusBadge:
+    """Tests for Project.get_status_badge() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        self.user = User.objects.create_user(
+            username="testuser_project",
+            email="project@example.com",
+            password=TEST_PASSWORD,
+        )
+
+    def test_draft_returns_neutral_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Draft Project",
+            status=Project.Status.DRAFT,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.NEUTRAL
+        assert badge.text == "Draft"
+
+    def test_submitted_returns_info_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Submitted Project",
+            status=Project.Status.SUBMITTED,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.INFO
+        assert badge.text == "Submitted"
+
+    def test_checking_returns_processing_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Checking Project",
+            status=Project.Status.CHECKING,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.PROCESSING
+        assert badge.text == "Checking"
+
+    def test_manufacturable_returns_success_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Manufacturable Project",
+            status=Project.Status.MANUFACTURABLE,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.text == "Manufacturable"
+
+    def test_not_manufacturable_returns_danger_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Not Manufacturable Project",
+            status=Project.Status.NOT_MANUFACTURABLE,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.DANGER
+        assert badge.text == "Not Manufacturable"
+
+    def test_assigned_returns_info_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Assigned Project",
+            status=Project.Status.ASSIGNED_TO_SHUTTLE,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.INFO
+        assert badge.text == "Assigned to Shuttle"
+
+    def test_in_production_returns_processing_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Production Project",
+            status=Project.Status.IN_PRODUCTION,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.PROCESSING
+        assert badge.text == "In Production"
+
+    def test_completed_returns_success_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Completed Project",
+            status=Project.Status.COMPLETED,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.text == "Completed"
+
+    def test_cancelled_returns_neutral_badge(self) -> None:
+        project = Project.objects.create(
+            user=self.user,
+            name="Cancelled Project",
+            status=Project.Status.CANCELLED,
+        )
+        badge = project.get_status_badge()
+
+        assert badge.badge_type == BadgeType.NEUTRAL
+        assert badge.text == "Cancelled"

--- a/wafer_space/projects/tests/test_badges.py
+++ b/wafer_space/projects/tests/test_badges.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import pytest
 
 from wafer_space.core.badges import BadgeType
+from wafer_space.projects.models import DownloadAttempt
 from wafer_space.projects.models import Project
+from wafer_space.projects.models import ProjectFile
 from wafer_space.users.models import User
-
-from .constants import TEST_PASSWORD
 
 
 class TestProjectStatusBadge:
@@ -17,10 +17,10 @@ class TestProjectStatusBadge:
     @pytest.fixture(autouse=True)
     def setup(self, db):
         """Set up test fixtures."""
+        # No password needed - these tests never authenticate
         self.user = User.objects.create_user(
             username="testuser_project",
             email="project@example.com",
-            password=TEST_PASSWORD,
         )
 
     def test_draft_returns_neutral_badge(self) -> None:
@@ -121,3 +121,75 @@ class TestProjectStatusBadge:
 
         assert badge.badge_type == BadgeType.NEUTRAL
         assert badge.text == "Cancelled"
+
+
+class TestDownloadAttemptBadge:
+    """Tests for DownloadAttempt.get_badge() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        """Set up test fixtures."""
+        # No password needed - these tests never authenticate
+        self.user = User.objects.create_user(
+            username="testuser_attempt",
+            email="attempt@example.com",
+        )
+        self.project = Project.objects.create(
+            user=self.user,
+            name="Test Project Attempt",
+            description="Test project",
+        )
+        self.project_file = ProjectFile.objects.create(
+            project=self.project,
+            original_url="https://example.com/test.gds",
+            source_url="https://example.com/test.gds",
+            original_filename="test.gds",
+        )
+
+    def test_pending_returns_neutral_badge(self) -> None:
+        attempt = DownloadAttempt.objects.create(
+            project_file=self.project_file,
+            attempt_number=1,
+            status=DownloadAttempt.Status.PENDING,
+        )
+        badge = attempt.get_badge()
+
+        assert badge.badge_type == BadgeType.NEUTRAL
+        assert badge.text == "Pending"
+        assert badge.icon == "bi-clock"
+
+    def test_downloading_returns_processing_badge(self) -> None:
+        attempt = DownloadAttempt.objects.create(
+            project_file=self.project_file,
+            attempt_number=1,
+            status=DownloadAttempt.Status.DOWNLOADING,
+        )
+        badge = attempt.get_badge()
+
+        assert badge.badge_type == BadgeType.PROCESSING
+        assert badge.text == "Downloading"
+        assert badge.icon is None  # Processing badges use spinner, not icon
+
+    def test_completed_returns_success_badge(self) -> None:
+        attempt = DownloadAttempt.objects.create(
+            project_file=self.project_file,
+            attempt_number=1,
+            status=DownloadAttempt.Status.COMPLETED,
+        )
+        badge = attempt.get_badge()
+
+        assert badge.badge_type == BadgeType.SUCCESS
+        assert badge.text == "Completed"
+        assert badge.icon == "bi-check-circle"
+
+    def test_failed_returns_danger_badge(self) -> None:
+        attempt = DownloadAttempt.objects.create(
+            project_file=self.project_file,
+            attempt_number=1,
+            status=DownloadAttempt.Status.FAILED,
+        )
+        badge = attempt.get_badge()
+
+        assert badge.badge_type == BadgeType.DANGER
+        assert badge.text == "Failed"
+        assert badge.icon == "bi-exclamation-triangle"

--- a/wafer_space/templates/core/_badge.html
+++ b/wafer_space/templates/core/_badge.html
@@ -1,0 +1,11 @@
+{# Reusable badge component - renders a single BadgeInfo #}
+{# Used by {% render_badge badge %} template tag #}
+<span class="badge {{ css_class }}">
+  {% if is_processing %}
+    <span class="spinner-border spinner-border-sm me-1"
+          role="status"
+          aria-hidden="true"></span>
+  {% endif %}
+  {% if icon and not is_processing %}<i class="{{ icon }} me-1" aria-hidden="true"></i>{% endif %}
+  {{ text }}
+</span>

--- a/wafer_space/templates/projects/_download_attempt.html
+++ b/wafer_space/templates/projects/_download_attempt.html
@@ -6,6 +6,8 @@
 {#   - show_checkpoints: (optional, default=True) Show download checkpoints #}
 {#   - show_errors: (optional, default=True) Show errors #}
 {#   - show_technical_details: (optional, default=False) Show technical error details #}
+{% load badges %}
+
 <div class="card mb-2 {% if is_latest %}border-primary{% endif %}">
   <details {% if start_open %}open{% endif %}>
     <summary class="card-header py-2 {% if is_latest %}bg-primary bg-opacity-10{% endif %}"
@@ -16,20 +18,7 @@
           Attempt #{{ attempt.attempt_number }}
           {% if is_latest %}<span class="badge bg-primary ms-1">Latest</span>{% endif %}
         </strong>
-        <span class="badge {% if attempt.status == 'completed' %}bg-success{% elif attempt.status == 'failed' %}bg-danger{% elif attempt.status == 'downloading' %}bg-primary{% else %}bg-secondary{% endif %}">
-          {% if attempt.status == 'completed' %}
-            <i class="bi bi-check-circle"></i>
-          {% elif attempt.status == 'failed' %}
-            <i class="bi bi-exclamation-triangle"></i>
-          {% elif attempt.status == 'downloading' %}
-            <span class="spinner-border spinner-border-sm"
-                  role="status"
-                  aria-hidden="true"></span>
-          {% else %}
-            <i class="bi bi-clock"></i>
-          {% endif %}
-          {{ attempt.get_status_display }}
-        </span>
+        {% render_badge attempt.get_badge %}
       </div>
     </summary>
     <div class="card-body py-2">

--- a/wafer_space/templates/projects/_file_badges.html
+++ b/wafer_space/templates/projects/_file_badges.html
@@ -1,55 +1,25 @@
-{% load precheck_tags %}
+{% load badges precheck_tags %}
 
 {# Reusable file status badges partial #}
 {# Parameters: #}
 {#   - file: ProjectFile instance #}
 {#   - layout: "vertical" (stacked) or "horizontal" (inline), default "horizontal" #}
-{#   - show_download_status: (optional, default=True) Show download status badge #}
-{% with latest_attempt=file.latest_attempt %}
-  {% with status=latest_attempt.status|default:"pending" %}
-    <div class="d-flex {% if layout == 'vertical' %}flex-column align-items-end{% endif %} gap-1 {% if layout != 'vertical' %}align-items-center{% endif %}">
-      {# Manufacturability check status badge (most relevant) #}
-      {% with check=file.latest_manufacturability_check %}
-        {% if check %}
-          {% badge_check_status_and_version check %}
-        {% endif %}
-      {% endwith %}
-      {# Hash verification badge #}
-      {% if file.hash_verified %}
-        <span class="badge bg-success">
-          <i class="bi bi-shield-check"></i> Hash Verified
-        </span>
-      {% elif status == 'completed' and file.has_hash_mismatch %}
-        <span class="badge bg-danger">
-          <i class="bi bi-shield-x"></i> Hash Mismatch
-        </span>
-      {% elif status == 'completed' and file.has_expected_hash and not file.hash_verified %}
-        <span class="badge bg-warning text-dark">
-          <i class="bi bi-shield-exclamation"></i> Hash Not Verified
-        </span>
-      {% endif %}
-      {# Download status badge #}
-      {% if show_download_status != False %}
-        <span class="badge {% if status == 'completed' and file.has_hash_mismatch %}bg-danger{% elif status == 'completed' %}bg-success{% elif status == 'failed' %}bg-danger{% elif status == 'downloading' %}bg-primary{% else %}bg-secondary{% endif %}">
-          {% if status == 'completed' and file.has_hash_mismatch %}
-            <i class="bi bi-exclamation-triangle"></i> Hash Mismatch
-          {% elif status == 'completed' %}
-            <i class="bi bi-check-circle"></i> Downloaded
-          {% elif status == 'failed' %}
-            <i class="bi bi-exclamation-triangle"></i> Download Failed
-          {% elif status == 'downloading' %}
-            <span class="spinner-border spinner-border-sm" role="status"></span> Downloading
-          {% else %}
-            <i class="bi bi-clock"></i> Pending
-          {% endif %}
-        </span>
-      {% endif %}
-      {# Active file indicator #}
-      {% if file.is_active and show_active %}
-        <span class="badge bg-info">
-          <i class="bi bi-star-fill"></i> Active
-        </span>
-      {% endif %}
-    </div>
+{#   - show_active: (optional, default=False) Show active file indicator #}
+<div class="d-flex {% if layout == 'vertical' %}flex-column align-items-end{% endif %} gap-1 {% if layout != 'vertical' %}align-items-center{% endif %}">
+  {# Manufacturability check status badge (most relevant) #}
+  {% with check=file.latest_manufacturability_check %}
+    {% if check %}
+      {% badge_check_status_and_version check %}
+    {% endif %}
   {% endwith %}
-{% endwith %}
+  {# Download / hash pipeline badges #}
+  {% for badge in file.get_badges %}
+    {% render_badge badge %}
+  {% endfor %}
+  {# Active file indicator #}
+  {% if file.is_active and show_active %}
+    <span class="badge bg-info">
+      <i class="bi bi-star-fill" aria-hidden="true"></i> Active
+    </span>
+  {% endif %}
+</div>

--- a/wafer_space/templates/projects/_file_display.html
+++ b/wafer_space/templates/projects/_file_display.html
@@ -1,4 +1,4 @@
-{% load static precheck_tags %}
+{% load static badges precheck_tags %}
 
 {# Reusable file display partial - used for both submitted and in-progress files #}
 {# Parameters: #}
@@ -90,49 +90,19 @@
           {% if file.hash_md5 %}
             <p class="mb-1">
               <strong>MD5:</strong> <code>{{ file.hash_md5 }}</code>
-              {% if file.expected_hash_md5 %}
-                {% if file.hash_md5|lower == file.expected_hash_md5|lower %}
-                  <span class="badge bg-success">
-                    <i class="bi bi-check-circle"></i> Verified
-                  </span>
-                {% else %}
-                  <span class="badge bg-danger">
-                    <i class="bi bi-x-circle"></i> Mismatch
-                  </span>
-                {% endif %}
-              {% endif %}
+              {% render_inline_hash_badge file 'md5' %}
             </p>
           {% endif %}
           {% if file.hash_sha1 %}
             <p class="mb-1">
               <strong>SHA1:</strong> <code>{{ file.hash_sha1 }}</code>
-              {% if file.expected_hash_sha1 %}
-                {% if file.hash_sha1|lower == file.expected_hash_sha1|lower %}
-                  <span class="badge bg-success">
-                    <i class="bi bi-check-circle"></i> Verified
-                  </span>
-                {% else %}
-                  <span class="badge bg-danger">
-                    <i class="bi bi-x-circle"></i> Mismatch
-                  </span>
-                {% endif %}
-              {% endif %}
+              {% render_inline_hash_badge file 'sha1' %}
             </p>
           {% endif %}
           {% if file.hash_sha256 %}
             <p class="mb-1">
               <strong>SHA256:</strong> <code>{{ file.hash_sha256 }}</code>
-              {% if file.expected_hash_sha256 %}
-                {% if file.hash_sha256|lower == file.expected_hash_sha256|lower %}
-                  <span class="badge bg-success">
-                    <i class="bi bi-check-circle"></i> Verified
-                  </span>
-                {% else %}
-                  <span class="badge bg-danger">
-                    <i class="bi bi-x-circle"></i> Mismatch
-                  </span>
-                {% endif %}
-              {% endif %}
+              {% render_inline_hash_badge file 'sha256' %}
             </p>
           {% endif %}
         {% endif %}

--- a/wafer_space/templates/projects/compliance_certification_form.html
+++ b/wafer_space/templates/projects/compliance_certification_form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags badges %}
 
 {% block title %}
   Export Compliance Certification - {{ project.name }}
@@ -132,7 +132,7 @@
               </dd>
               <dt class="col-sm-5">Status:</dt>
               <dd class="col-sm-7">
-                <span class="badge bg-success">{{ project.get_status_display }}</span>
+                {% render_badge project.get_status_badge %}
               </dd>
               <dt class="col-sm-5">Owner:</dt>
               <dd class="col-sm-7">

--- a/wafer_space/templates/projects/project_detail.html
+++ b/wafer_space/templates/projects/project_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static %}
+{% load static badges %}
 
 {% block title %}
   {{ project.name }}
@@ -78,9 +78,7 @@
               <div class="card-body">
                 <p class="mb-2">
                   <strong>Status:</strong>
-                  <span class="badge {% if project.status == 'draft' %}bg-secondary{% elif project.status == 'submitted' %}bg-primary{% elif project.status == 'manufacturable' %}bg-success{% elif project.status == 'not_manufacturable' %}bg-danger{% else %}bg-info{% endif %}">
-                    {{ project.get_status_display }}
-                  </span>
+                  {% render_badge project.get_status_badge %}
                 </p>
                 <p class="mb-2">
                   <strong>Submitted:</strong>

--- a/wafer_space/templates/projects/project_detail.html
+++ b/wafer_space/templates/projects/project_detail.html
@@ -419,8 +419,6 @@
               const progressBar = document.getElementById('progress-bar');
               const progressText = document.getElementById('progress-text');
               const progressMessage = document.getElementById('progress-message');
-              const statusBadge = document.getElementById('status-badge');
-              const statusText = document.getElementById('status-text');
 
               if (progressBar && progressText) {
                 progressBar.style.width = data.progress + '%';
@@ -432,42 +430,8 @@
                 progressMessage.textContent = data.message;
               }
 
-              // Update status badge
-              if (statusBadge && statusText && data.status) {
-                console.log('[Progress Polling] Updating status badge to:', data.status);
-                // Update badge color and icon based on status
-                statusBadge.className = 'badge';
-                let iconHtml = '';
-
-                if (data.status === 'completed') {
-                  statusBadge.classList.add('bg-success');
-                  iconHtml = '<i class="bi bi-check-circle"></i> ';
-                  statusText.textContent = 'Download Completed';
-                } else if (data.status === 'failed') {
-                  statusBadge.classList.add('bg-danger');
-                  iconHtml = '<i class="bi bi-exclamation-triangle"></i> ';
-                  statusText.textContent = 'Download Failed';
-                } else if (data.status === 'downloading') {
-                  statusBadge.classList.add('bg-primary');
-                  iconHtml = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ';
-                  statusText.textContent = 'Downloading';
-                } else if (data.status === 'queued') {
-                  statusBadge.classList.add('bg-info');
-                  iconHtml = '<i class="bi bi-clock"></i> ';
-                  statusText.textContent = 'Queued';
-                } else if (data.status === 'retrying') {
-                  statusBadge.classList.add('bg-warning');
-                  iconHtml = '<i class="bi bi-arrow-clockwise"></i> ';
-                  statusText.textContent = 'Retrying';
-                } else {
-                  statusBadge.classList.add('bg-secondary');
-                  iconHtml = '<i class="bi bi-clock"></i> ';
-                  statusText.textContent = data.status;
-                }
-
-                // Update the badge content with icon + text
-                statusBadge.innerHTML = iconHtml + '<span id="status-text">' + statusText.textContent + '</span>';
-              }
+              // Status badges are server-rendered (see _file_badges.html);
+              // the page reload below refreshes them on completion.
 
               // Stop polling and reload if completed or failed
               if (data.status === 'completed' || data.status === 'failed') {

--- a/wafer_space/templates/projects/project_list.html
+++ b/wafer_space/templates/projects/project_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static %}
+{% load static badges %}
 
 {% block title %}
   My Projects
@@ -46,6 +46,12 @@
                   <small class="text-muted">{{ project.created_at|date:"M d, Y" }}</small>
                 </div>
                 {% if project.description %}<p class="mb-1">{{ project.description|truncatewords:30 }}</p>{% endif %}
+                <div class="d-flex gap-1 mt-2">
+                  {% render_badge project.get_status_badge %}
+                  {% for badge in project.get_badges %}
+                    {% render_badge badge %}
+                  {% endfor %}
+                </div>
               </a>
             {% endfor %}
           </div>


### PR DESCRIPTION
## Summary

Rebuilt on top of current main (2026-06-11), keeping only the parts of the original badge standardization that main has not since implemented its own way.

- Create unified badge system with `BadgeType` enum and `BadgeInfo` dataclass in `wafer_space/core/badges.py`, with `{% render_badge %}` / `{% render_inline_hash_badge %}` template tags and a shared `core/_badge.html` partial (`wafer_space.core` registered as an installed app)
- Add badge methods: `Project.get_status_badge()` / `get_badges()`, `ProjectFile.get_download_badge()` / `get_hash_badge()` / `get_inline_hash_badge()` / `get_badges()`, `DownloadAttempt.get_badge()`, `Notification.get_type_badge()`
- Convert the still-hardcoded badges: project status on detail page (covered 4 of 9 statuses), compliance form status (was always green regardless of status), notification types (covered 4 of 6), download attempt status, file hash/download badges, inline MD5/SHA1/SHA256 Verified/Mismatch badges
- Add status badges to the project list page
- Remove the dead download-badge JS in `project_detail.html` (no `#status-badge` element exists; the poller reloads the page on completion)

## Scope change vs. the original PR

Manufacturability check badges are **out of scope**: main built its own check badge system in December 2025 (`_STATUS_METADATA` on the model + `precheck_tags` template tags, see `docs/plans/2025-12-12-status-metadata-refactor.md`) with container-version indicators this framework does not model. Templates mix both systems side by side (`_file_badges.html`). The `ProjectFile.get_badges()` pipeline is therefore Download → Hash only.

The AJAX `badge_html` additions from the original PR were dropped for the same reason: the live badge they fed no longer exists and check transitions trigger a page reload on main.

## Fixes

- Fixes #114 - Projects page now shows status badges for each project
- Compliance certification form no longer shows a green badge for every project status
- #113 / #115 / #116 were partially addressed by main's `_STATUS_METADATA` refactor for checks; this PR completes badge consistency for non-check badges

## Test Plan

- [x] 58 new badge-specific tests (all passing)
- [x] 1341 total tests passing, 3 skipped (full suite, including browser tests)
- [x] Linting clean (ruff), type checking clean (mypy), templates clean (djlint)
- [ ] Visual verification on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced a centralized badge system for displaying project status, download progress, file verification results, and notification states throughout the application with consistent visual styling and icons.

* **Documentation**
  * Added comprehensive design documentation for the badge system, including usage examples and state mappings.

* **Tests**
  * Added unit tests covering badge creation, rendering, and state-specific badge generation across all system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->