### PR TITLE
fix: make Name field in admin summary page link to project

### DIFF
--- a/wafer_space/templates/projects/admin_summary.html
+++ b/wafer_space/templates/projects/admin_summary.html
@@ -169,7 +169,9 @@
             <tr>
               <td class="font-monospace">{{ project.full_id|default:"-" }}</td>
               <td>{{ project.slot_size }}</td>
-              <td>{{ project.name }}</td>
+              <td>
+                <a href="{% url 'projects:detail' pk=project.pk %}">{{ project.name }}</a>
+              </td>
               <td>{{ project.user.username }}</td>
               <td>{{ project.user.email }}</td>
               {% with active_file=project.active_files.0 %}


### PR DESCRIPTION
## Summary
- Makes the Name column in the admin summary page (`/projects/admin/summary/`) link to the project detail page for easier navigation

## Test plan
- [x] All tests pass
- [ ] Verify Name column is now clickable in admin summary page
- [ ] Verify clicking Name navigates to project detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project names in the Projects table are now clickable links that open each project's detail page for faster navigation.

* **Chores**
  * Minor UI update converting the project name display into a navigable link with no changes to underlying data or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->