### PR TITLE
fix: disable default DJANGO_SETTINGS_MODULE to fail fast

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 
-import os
+import os  # noqa: F401 - used by commented-out setdefault below
 import sys
 from pathlib import Path
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.dev")
+    # Disabled: fail fast if DJANGO_SETTINGS_MODULE not set, don't silently use SQLite.
+    # https://github.com/wafer-space/platform.wafer.space/issues/152
+    # os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.dev")  # noqa: ERA001, E501
 
     try:
         from django.core.management import execute_from_command_line  # noqa: PLC0415


### PR DESCRIPTION
## Summary

- Comment out the `setdefault` in `manage.py` that defaulted to dev settings
- Without this, running `manage.py` on production without sourcing `.env` silently uses SQLite instead of PostgreSQL, causing misdiagnosis of issues

## Root Cause

When `.env` is not sourced on a production server:
1. `DJANGO_SETTINGS_MODULE` is not set
2. `manage.py` defaults to `config.settings.dev`
3. `dev.py` hardcodes SQLite, ignoring `DATABASE_URL`
4. Queries return nothing because they hit an empty local SQLite file
5. Operator thinks production database is broken

## Fix

Comment out the default so Django fails fast with a clear error if the environment isn't configured.

Fixes #152

## Test plan

- [x] All tests pass (943 passed)
- [x] Lint checks pass
- [ ] Verify `./manage.py shell` fails without `.env` sourced

🤖 Generated with [Claude Code](https://claude.com/claude-code)