### PR TITLE
fix: ignore .worktrees symlinks in addition to directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,4 +308,4 @@ client_secret_*.json
 secrets/
 
 # Git worktrees (isolated workspaces)
-.worktrees/
+.worktrees


### PR DESCRIPTION
## Summary

- Remove trailing slash from `.worktrees/` pattern in `.gitignore`
- The trailing slash only matches directories, not symlinks
- Without the slash, the pattern matches files, symlinks, and directories

## Test plan

- [x] Verified `.worktrees` symlink no longer appears as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)