### PR TITLE
fix: Allow admins/superusers to cancel manufacturing checks

### DIFF
--- a/wafer_space/projects/tests/test_views.py
+++ b/wafer_space/projects/tests/test_views.py
@@ -1333,7 +1333,7 @@ class TestManufacturabilityCheckCancelView(TestCase):
         assert "/accounts/login/" in response["Location"]
 
     def test_cancel_check_requires_ownership(self):
-        """Test that only project owner can cancel check."""
+        """Test that non-owner, non-staff users cannot cancel check."""
         ManufacturabilityCheck.objects.create(
             project=self.project,
             project_file=self.project_file,
@@ -1385,7 +1385,7 @@ class TestManufacturabilityCheckCancelView(TestCase):
         check.refresh_from_db()
         assert check.status == ManufacturabilityCheck.Status.CANCELLING
         # Verify admin cancellation is logged
-        assert f"Cancelled by admin ({staff_user.email})" in check.processing_logs
+        assert f"Cancelled by admin ({staff_user.username})" in check.processing_logs
 
     def test_superuser_can_cancel_any_check(self):
         """Test that superusers can cancel any project's check."""
@@ -1408,7 +1408,7 @@ class TestManufacturabilityCheckCancelView(TestCase):
         check.refresh_from_db()
         assert check.status == ManufacturabilityCheck.Status.CANCELLING
         # Verify admin cancellation is logged
-        assert f"Cancelled by admin ({superuser.email})" in check.processing_logs
+        assert f"Cancelled by admin ({superuser.username})" in check.processing_logs
 
     def test_owner_cancel_logs_correct_reason(self):
         """Test that owner cancellation logs 'Cancelled by owner'."""

--- a/wafer_space/projects/views.py
+++ b/wafer_space/projects/views.py
@@ -500,7 +500,7 @@ class ManufacturabilityCheckCancelView(LoginRequiredMixin, UserPassesTestMixin, 
             if project.user == request.user:
                 reason = "Cancelled by owner"
             else:
-                reason = f"Cancelled by admin ({request.user.email})"
+                reason = f"Cancelled by admin ({request.user.username})"
             check.mark_cancelling(reason=reason)
             messages.success(request, "Cancellation requested. Cleanup in progress...")
         except InvalidStateTransitionError:


### PR DESCRIPTION
## Summary
- Fixes permission check in `ManufacturabilityCheckCancelView` to allow staff users and superusers to cancel any project's manufacturability check
- Updates cancellation reason logging to distinguish between owner-initiated ("Cancelled by owner") and admin-initiated ("Cancelled by admin (email@example.com)") cancellations

## Test plan
- [x] Added `test_staff_user_can_cancel_any_check` - verifies staff can cancel any check
- [x] Added `test_superuser_can_cancel_any_check` - verifies superuser can cancel any check
- [x] Added `test_owner_cancel_logs_correct_reason` - verifies owner cancellation logs correctly
- [x] Existing test `test_cancel_check_requires_ownership` still passes (non-owner regular user still gets 403)
- [x] All 956 tests pass

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff and superusers can now cancel pending manufacturability checks in addition to owners.
  * Cancellation records indicate whether an admin or the owner initiated the action.

* **Bug Fixes**
  * Users now receive a warning message when a cancellation cannot proceed due to an invalid state.

* **Tests**
  * Added tests for owner, staff, and superuser cancellation paths and corresponding audit log entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->