### PR TITLE
config: increase precheck timeout from 12 to 20 hours

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -445,7 +445,7 @@ DOWNLOAD_STATE_CHECK_INTERVAL_SECONDS = 60.0  # Check every 1 minute
 # See: Design document for manufacturability checking implementation
 PRECHECK_DOCKER_IMAGE = "ghcr.io/wafer-space/gf180mcu-precheck:latest"
 PRECHECK_CONCURRENT_LIMIT = 4
-PRECHECK_TIMEOUT_SECONDS = 12 * 60 * 60  # 12 hours hard limit
+PRECHECK_TIMEOUT_SECONDS = 20 * 60 * 60  # 20 hours hard limit
 PRECHECK_SOFT_TIMEOUT_BUFFER = 60 * 60  # 1 hour buffer before hard limit
 PRECHECK_SCAN_INTERVAL_SECONDS = 30.0  # Scan for files ready to check every 30s
 


### PR DESCRIPTION
## Summary
- Extend the hard timeout limit for manufacturability checks from 12 to 20 hours
- Accommodates longer-running precheck workloads

## Test plan
- [ ] Verify timeout setting is correctly applied in staging/production
- [ ] Monitor long-running prechecks to confirm they complete within the new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout duration for precheck manufacturability validation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->