### PR TITLE
fix: use settings.PRECHECK_CONCURRENT_LIMIT in mark_dispatched

### DIFF
--- a/wafer_space/projects/models.py
+++ b/wafer_space/projects/models.py
@@ -1143,9 +1143,6 @@ class ManufacturabilityCheck(models.Model):
     # Maximum characters of processing logs to include in GitHub issue body
     GITHUB_ISSUE_LOG_CHARS: ClassVar[int] = 5000
 
-    # Maximum concurrent checks allowed (DISPATCHED + RUNNING)
-    MAX_CONCURRENT_CHECKS: ClassVar[int] = 4
-
     # Statuses representing checks that are in progress and should be
     # cancelled when the project file is replaced
     IN_PROGRESS_STATUSES: ClassVar[list[Status]] = [
@@ -1360,10 +1357,11 @@ class ManufacturabilityCheck(models.Model):
             .count()
         )
 
-        if active_count >= self.MAX_CONCURRENT_CHECKS:
+        concurrent_limit = settings.PRECHECK_CONCURRENT_LIMIT
+        if active_count >= concurrent_limit:
             raise ConcurrentLimitError(
                 active_count=active_count,
-                max_concurrent=self.MAX_CONCURRENT_CHECKS,
+                max_concurrent=concurrent_limit,
             )
 
         self.status = self.Status.DISPATCHED


### PR DESCRIPTION
## Summary

- Remove hardcoded `MAX_CONCURRENT_CHECKS = 4` class variable from `ManufacturabilityCheck` model
- Update `mark_dispatched()` to read from `settings.PRECHECK_CONCURRENT_LIMIT` instead

## Problem

Production was only dispatching 4 prechecks instead of the configured 9. The root cause was a duplicate limit:

1. `settings.PRECHECK_CONCURRENT_LIMIT = 9` (in prod.py) - used by `checks_dispatch` task
2. `MAX_CONCURRENT_CHECKS: ClassVar[int] = 4` (in models.py) - used by `mark_dispatched()`

PR #181 updated the settings value but missed the model's hardcoded class variable.

## Test plan

- [x] All 969 tests pass
- [x] Lint and type-check pass
- [ ] Deploy to production and verify 9 concurrent checks are dispatched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Concurrency limits for manufacturability and precheck operations are now configurable through system settings, replacing a hard-coded limit. This enables better customization of concurrent processing behavior based on system requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->