### PR TITLE
fix: set Docker client timeout to 5 minutes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -441,6 +441,11 @@ DOWNLOAD_TASK_RETRY_BACKOFF_MULTIPLIER = 2  # Exponential backoff: 60s, 120s
 # Fallback system to detect orphaned tasks and recover from queue loss
 DOWNLOAD_STATE_CHECK_INTERVAL_SECONDS = 60.0  # Check every 1 minute
 
+# Docker client configuration
+# ------------------------------------------------------------------------------
+# Timeout for Docker SDK HTTP client (default 60s is too short for some operations)
+DOCKER_CLIENT_TIMEOUT = 300  # 5 minutes
+
 # Precheck (Manufacturability Checking) configuration
 # See: Design document for manufacturability checking implementation
 PRECHECK_DOCKER_IMAGE = "ghcr.io/wafer-space/gf180mcu-precheck:latest"

--- a/wafer_space/projects/tasks.py
+++ b/wafer_space/projects/tasks.py
@@ -825,7 +825,7 @@ def _setup_docker_context(check, project_file, task_instance, logger):
         _CheckContext: Execution context for the check
     """
     logger.info("Step 2: Connecting to Docker daemon...")
-    client = docker.from_env(timeout=300)
+    client = docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT)
     docker_info = client.info()
     logger.info("  ✓ Docker connected: %s", docker_info.get("Name", "unknown"))
     logger.info("  ✓ Docker version: %s", docker_info.get("ServerVersion", "unknown"))
@@ -2804,7 +2804,7 @@ def checks_cleanup_orphaned_docker() -> dict:
     logger.info("=" * 60)
 
     try:
-        client = docker.from_env(timeout=300)
+        client = docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT)
     except docker.errors.DockerException as exc:
         logger.exception("Failed to connect to Docker")
         return {
@@ -3180,7 +3180,7 @@ def checks_cancelling() -> dict:
         cancelling_count,
     )
 
-    client = docker.from_env(timeout=300)
+    client = docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT)
 
     for check in cancelling_checks:
         logger.info(

--- a/wafer_space/projects/verification.py
+++ b/wafer_space/projects/verification.py
@@ -10,6 +10,7 @@ import docker
 import docker.errors
 import psutil
 from celery import current_app
+from django.conf import settings
 from django.db import DatabaseError
 from django.db import connection
 
@@ -37,7 +38,7 @@ def is_check_container_running(check: ManufacturabilityCheck) -> bool | None:
         None if Docker unavailable (caller should fall back to other checks)
     """
     try:
-        client = docker.from_env(timeout=300)
+        client = docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT)
     except docker.errors.DockerException:
         logger.warning(
             "Failed to connect to Docker - cannot verify container for check %s",


### PR DESCRIPTION
## Summary

- Set `timeout=300` (5 minutes) on all `docker.from_env()` calls
- The Docker SDK's HTTP client defaults to 60 seconds, causing "Read timed out" errors when Docker API operations take longer
- Affects: `wafer_space/projects/tasks.py` (3 locations) and `wafer_space/projects/verification.py` (1 location)

## Test plan

- [ ] Verify long-running Docker operations no longer timeout
- [ ] Confirm Docker connection still fails gracefully when Docker is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker client now uses a configurable timeout to reduce premature connection failures and improve reliability of background Docker operations.

* **New Features**
  * Added a new configuration setting to control the Docker client timeout, making timeout behavior adjustable without code changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->