### PR TITLE
fix: serialize dispatch to prevent Docker API overload

### DIFF
--- a/wafer_space/projects/tasks.py
+++ b/wafer_space/projects/tasks.py
@@ -2884,6 +2884,8 @@ def checks_cleanup_orphaned_docker() -> dict:
 def checks_dispatch() -> dict:
     """Dispatch PENDING checks to Celery queue (respecting concurrent limit).
 
+    Only one check can be DISPATCHED at a time to prevent overloading the
+    Docker API with concurrent image pulls and container creation.
     CANCELLING checks count toward the limit because their Docker containers
     may still be running.
 
@@ -2892,6 +2894,17 @@ def checks_dispatch() -> dict:
     """
     logger = logging.getLogger(__name__)
     logger.info("[checks_dispatch] Starting dispatch cycle")
+
+    # Only dispatch one check at a time to avoid overloading Docker API
+    dispatched_count = ManufacturabilityCheck.objects.filter(
+        status=ManufacturabilityCheck.Status.DISPATCHED,
+    ).count()
+    if dispatched_count > 0:
+        logger.info(
+            "[checks_dispatch] Skipping - %d check(s) already dispatching",
+            dispatched_count,
+        )
+        return {"dispatched": 0, "waiting": -1, "reason": "dispatch_in_progress"}
 
     concurrent_limit = getattr(settings, "PRECHECK_CONCURRENT_LIMIT", 4)
 
@@ -2904,11 +2917,10 @@ def checks_dispatch() -> dict:
         ],
     ).count()
 
-    pending = ManufacturabilityCheck.objects.filter(
+    pending_count = ManufacturabilityCheck.objects.filter(
         status=ManufacturabilityCheck.Status.PENDING,
-    ).order_by("created_at")
+    ).count()
 
-    pending_count = pending.count()
     logger.info(
         "[checks_dispatch] Active: %d/%d, Pending: %d",
         active_count,
@@ -2916,34 +2928,41 @@ def checks_dispatch() -> dict:
         pending_count,
     )
 
-    dispatched = 0
-    for check in pending:
-        if active_count >= concurrent_limit:
-            logger.info(
-                "[checks_dispatch] Concurrent limit reached (%d/%d), stopping",
-                active_count,
-                concurrent_limit,
-            )
-            break
-        task = check_process_job.delay(check.id)
-        check.mark_dispatched(celery_job_id=task.id)
+    # Check concurrent limit before dispatching
+    if active_count >= concurrent_limit:
         logger.info(
-            "[checks_dispatch] Dispatched check %s (project: %s, file: %s) -> task %s",
-            check.id,
-            check.project.name,
-            check.project_file.original_filename,
-            task.id,
+            "[checks_dispatch] Concurrent limit reached (%d/%d), not dispatching",
+            active_count,
+            concurrent_limit,
         )
-        active_count += 1
-        dispatched += 1
+        return {"dispatched": 0, "waiting": pending_count}
 
-    waiting = pending_count - dispatched
-    logger.info(
-        "[checks_dispatch] Complete: dispatched=%d, waiting=%d",
-        dispatched,
-        waiting,
+    # Dispatch only ONE check per cycle to serialize Docker API operations
+    check = (
+        ManufacturabilityCheck.objects.filter(
+            status=ManufacturabilityCheck.Status.PENDING,
+        )
+        .order_by("created_at")
+        .first()
     )
-    return {"dispatched": dispatched, "waiting": waiting}
+
+    if check is None:
+        logger.info("[checks_dispatch] No pending checks to dispatch")
+        return {"dispatched": 0, "waiting": 0}
+
+    task = check_process_job.delay(check.id)
+    check.mark_dispatched(celery_job_id=task.id)
+    logger.info(
+        "[checks_dispatch] Dispatched check %s (project: %s, file: %s) -> task %s",
+        check.id,
+        check.project.name,
+        check.project_file.original_filename,
+        task.id,
+    )
+
+    waiting = pending_count - 1
+    logger.info("[checks_dispatch] Complete: dispatched=1, waiting=%d", waiting)
+    return {"dispatched": 1, "waiting": waiting}
 
 
 @shared_task(queue="default")


### PR DESCRIPTION
## Summary

- Skip dispatch cycle if any check is already in DISPATCHED state
- Dispatch only one check per cycle instead of up to concurrent limit
- Multiple checks can still run concurrently once in RUNNING state

## Problem

When multiple checks are dispatched simultaneously, each dispatch operation requires Docker API calls (image pulls, container queries). Multiple concurrent dispatch operations overload the Docker API, causing timeout errors.

## Solution

Serialize the dispatch phase by:
1. Checking if any checks are already in DISPATCHED state - if so, skip this dispatch cycle
2. Dispatching only ONE check per cycle instead of multiple

This prevents Docker API overload while still allowing multiple checks to run concurrently once they transition to RUNNING state.

## Test plan

- [ ] Verify checks still get dispatched when queue is empty
- [ ] Verify only one check dispatches at a time
- [ ] Verify concurrent running checks still work

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)