### PR TITLE
fix: align Procfile queue names with actual Celery task queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,34 +1,16 @@
 # Procfile for local development with Honcho
 # Usage: honcho start
 #
-# Queue architecture mirrors production systemd services:
-# - default: general tasks (email, legal, misc project tasks)
-# - downloads: file download tasks (download_project_file)
-# - maintenance: cleanup/health check tasks (ensure_download_tasks_queued, checks_cleanup_stale_files)
-# - docker-persistent: long-running container tasks (check_process_job)
-# - docker-ephemeral: container orchestration/cleanup (checks_cancelling, checks_cleanup_failed_containers)
+# See docs/systemd-services.md for queue naming convention and task mappings.
+# Network/filesystem restrictions in queue names don't apply in development.
 
-# Django development server
 web: python manage.py runserver 8081
 
-# Celery worker for general tasks
-# Handles: default queue (email, legal tasks, misc), referrals, downloads
-# --concurrency=1: Single worker process for local development
-# --loglevel=info: Show task execution logs
-# --pool=solo: Use solo pool (simplest, single-threaded, good for debugging)
-worker: celery -A config worker -Q default,referrals,downloads --loglevel=info --concurrency=1 --pool=solo
+# Fast worker: quick tasks (orchestration, email, general, fast docker)
+worker-fast: celery -A config worker -Q none:ro:default,none:ro:checks-orch,mail:ro:email,dock:ro:checks-fast --loglevel=info --concurrency=1 --pool=solo
 
-# Celery worker for maintenance tasks (cleanup, health checks)
-# Separate worker ensures maintenance tasks run even when main worker is busy
-maintenance: celery -A config worker -Q maintenance --loglevel=info --concurrency=1 --pool=solo
+# Slow worker: long-running tasks (downloads, slow docker, result saving)
+worker-slow: celery -A config worker -Q http:rw:downloads,dock:ro:checks-slow,dock:rw:checks-save --loglevel=info --concurrency=2 --pool=threads
 
-# Celery worker for Docker-based manufacturability checks
-# Handles both persistent (check_process_job) and ephemeral (cleanup) tasks
-# In production these are separate services, but combined here for simplicity
-docker: celery -A config worker -Q docker-persistent,docker-ephemeral --loglevel=info --concurrency=1 --pool=solo
-
-# Celery Beat scheduler for periodic tasks
-# --loglevel=debug: Show scheduling logs
-# --schedule: SQLite database file for beat schedule
-# Runs periodic tasks defined in CELERY_BEAT_SCHEDULE
+# Celery Beat scheduler
 beat: celery -A config beat --loglevel=debug --schedule=celerybeat-schedule.sqlite3


### PR DESCRIPTION
## Summary

- Updates Procfile to use actual queue names matching task decorators (fixes tasks sitting unprocessed)
- Simplifies from 3 workers to 2 pools for development:
  - `worker-fast` (solo pool): quick tasks
  - `worker-slow` (threads pool): long-running I/O tasks
- Documents queue naming convention (`<network-access>:<mode>:<function>`)

## Test plan

- [ ] Run `honcho start` and verify both workers start without errors
- [ ] Trigger a file download and verify it gets processed by `worker-slow`
- [ ] Verify check orchestration tasks run on `worker-fast`

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized background worker processes into specialized pools for improved task distribution and handling efficiency.
  * Implemented standardized task queue naming convention for better organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->