### PR TITLE
fix: set staging checker server to 3 concurrent checks

### DIFF
--- a/config/settings/stage.py
+++ b/config/settings/stage.py
@@ -104,7 +104,7 @@ DOCKER_SERVERS = [
     {
         "id": "checker.wafer.space@buddy",
         "url": "tcp://10.2.27.44:2375",
-        "max_concurrent": 1,
+        "max_concurrent": 3,
         "priority": 1,
     },
 ]


### PR DESCRIPTION
## Summary
- Set `max_concurrent` to 3 for the buddy checker server in staging
- The previous PR (#225) was merged with `max_concurrent: 1` by mistake

## Test plan
- [ ] Verify staging can run 3 concurrent manufacturability checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging environment configuration to improve concurrent request handling capacity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->