### PR TITLE
fix: add script to fix docker digests and reset non-semver revisions

### DIFF
--- a/scripts/fix_docker_digests.py
+++ b/scripts/fix_docker_digests.py
@@ -148,6 +148,44 @@ def _reset_nonsemver_revisions(*, dry_run: bool) -> int:
     return len(revisions_to_reset)
 
 
+def _delete_orphaned_revisions(*, dry_run: bool) -> int:
+    """Delete PrecheckImageRevision records with no associated ManufacturabilityCheck.
+
+    These are orphaned records that were created for digests that no longer
+    exist in any ManufacturabilityCheck record.
+
+    Returns:
+        Number of records deleted (or would be deleted in dry run).
+    """
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("PART 3: Deleting orphaned PrecheckImageRevision records")
+    logger.info("=" * 60)
+
+    # Find revisions with no associated ManufacturabilityCheck
+    orphans = []
+    for revision in PrecheckImageRevision.objects.all():
+        check_count = ManufacturabilityCheck.objects.filter(
+            docker_image_digest=revision.digest
+        ).count()
+        if check_count == 0:
+            orphans.append(revision)
+            logger.info("  Found orphan: %s...", revision.digest[:50])
+
+    if orphans:
+        count = len(orphans)
+        logger.info("Found %d orphaned PrecheckImageRevision record(s)", count)
+        if not dry_run:
+            deleted = PrecheckImageRevision.objects.filter(
+                pk__in=[r.pk for r in orphans]
+            ).delete()
+            logger.info("Deleted %d orphaned record(s)", deleted[0])
+    else:
+        logger.info("No orphaned PrecheckImageRevision records found")
+
+    return len(orphans)
+
+
 def run(*args: str) -> None:
     """Run the digest fix script."""
     dry_run = "apply" not in args
@@ -165,12 +203,14 @@ def run(*args: str) -> None:
     with transaction.atomic():
         digests_fixed = _fix_digest_corrections(dry_run=dry_run)
         revisions_reset = _reset_nonsemver_revisions(dry_run=dry_run)
+        orphans_deleted = _delete_orphaned_revisions(dry_run=dry_run)
 
         logger.info("")
         logger.info("=" * 60)
         logger.info("SUMMARY:")
         logger.info("  ManufacturabilityCheck digests to fix: %d", digests_fixed)
         logger.info("  PrecheckImageRevision to reset: %d", revisions_reset)
+        logger.info("  Orphaned PrecheckImageRevision to delete: %d", orphans_deleted)
         logger.info("=" * 60)
 
         if dry_run:


### PR DESCRIPTION
## Summary

Adds `fix_docker_digests.py` script that:
1. Corrects ManufacturabilityCheck records with wrong docker digests (config digests instead of OCI index digests)
2. Resets PrecheckImageRevision records with non-semver precheck_version values (like "main") so they get re-fetched with the new semver-only version resolution logic from PR #237

## Usage

```bash
# Dry run (default) - shows what would be changed
uv run python manage.py runscript fix_docker_digests

# Actually apply the fixes
uv run python manage.py runscript fix_docker_digests --script-args apply
```

## Test plan

- [x] Lint and type checks pass
- [ ] Run dry run on test-platform to verify it finds the expected records
- [ ] Apply fix on test-platform
- [ ] Run `revisions_needs_fetching` task to re-fetch reset revisions
- [ ] Verify precheck_version is now semver-style

Fixes #233, #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stored Docker image digests to match canonical OCI index values.
  * Reset entries with non-semantic version tags so they can be re-fetched with proper versions.

* **Chores**
  * Added a maintenance utility with dry-run preview to safely validate fixes.
  * Operations run atomically to ensure consistent application or rollback of all changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->