### PR TITLE
fix: exclude NULL container_started_at from latest digest query

### DIFF
--- a/wafer_space/projects/models.py
+++ b/wafer_space/projects/models.py
@@ -2525,7 +2525,8 @@ Your GDS file should have:
         """Get the digest of the most recently used precheck image.
 
         Returns the docker_image_digest from the check with the most recent
-        container_started_at timestamp. Cached for 60 seconds.
+        container_started_at timestamp. Excludes checks that never started
+        (NULL container_started_at). Cached for 60 seconds.
         """
         cache_key = "precheck_latest_digest"
         cached = cache.get(cache_key)
@@ -2534,6 +2535,7 @@ Your GDS file should have:
 
         digest = (
             cls.objects.exclude(docker_image_digest="")
+            .exclude(container_started_at__isnull=True)
             .order_by("-container_started_at")
             .values_list("docker_image_digest", flat=True)
             .first()

--- a/wafer_space/projects/tests/test_precheck_revision.py
+++ b/wafer_space/projects/tests/test_precheck_revision.py
@@ -197,6 +197,26 @@ class TestManufacturabilityCheckLatestDigest:
         """get_latest_precheck_digest returns None when no checks exist."""
         assert ManufacturabilityCheck.get_latest_precheck_digest() is None
 
+    def test_get_latest_precheck_digest_ignores_null_started_at(self):
+        """get_latest_precheck_digest ignores checks with NULL container_started_at.
+
+        Regression test for issue #241: PostgreSQL sorts NULL values first in DESC
+        order, so checks that never started were incorrectly returned as "latest".
+        """
+        now = timezone.now()
+        # Valid check with timestamp
+        ManufacturabilityCheckFactory(
+            docker_image_digest="sha256:valid",
+            container_started_at=now - timedelta(hours=1),
+        )
+        # Check with NULL container_started_at (should be ignored)
+        ManufacturabilityCheckFactory(
+            docker_image_digest="sha256:null_started",
+            container_started_at=None,
+        )
+
+        assert ManufacturabilityCheck.get_latest_precheck_digest() == "sha256:valid"
+
     def test_is_using_latest_precheck_true(self):
         """is_using_latest_precheck returns True when using latest."""
         check = ManufacturabilityCheckFactory(


### PR DESCRIPTION
## Summary

- Fixes #241 
- PostgreSQL sorts NULL values first in DESC order, so checks that never started were incorrectly returned as "latest" by `get_latest_precheck_digest()`
- Added `.exclude(container_started_at__isnull=True)` to the query

## Test plan

- [x] Added regression test `test_get_latest_precheck_digest_ignores_null_started_at`
- [ ] All existing tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of precheck data with missing timestamp information to ensure the latest precheck digest is selected correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->