### PR TITLE
feat: add Latest File column to shuttle assignment dashboard

### DIFF
--- a/wafer_space/projects/models.py
+++ b/wafer_space/projects/models.py
@@ -452,6 +452,29 @@ class Project(models.Model):
         return ProjectFile(project=self, top_cell="")
 
     @property
+    def latest_file(self) -> "ProjectFile | None":
+        """Return the most recently created project file by ID.
+
+        This is the file with the highest ID, which represents the most
+        recently uploaded file regardless of is_active or submitted status.
+        Returns None if no files exist.
+        """
+        return self.files.order_by("-id").first()
+
+    @property
+    def latest_file_manufacturability_check(self) -> "ManufacturabilityCheck | None":
+        """Get the latest manufacturability check for the most recent file.
+
+        Returns the most recent check on the latest_file (by ID), or None if
+        no files or no checks exist. This may differ from
+        latest_manufacturability_check which uses the submitted_file.
+        """
+        latest = self.latest_file
+        if not latest:
+            return None
+        return latest.latest_manufacturability_check
+
+    @property
     def full_id(self) -> str:
         """Return full 8-character manufacturing ID (shuttle code + project ID).
 

--- a/wafer_space/shuttles/templates/shuttles/assignment_dashboard.html
+++ b/wafer_space/shuttles/templates/shuttles/assignment_dashboard.html
@@ -113,6 +113,13 @@
                 Size <span class="sort-indicator"></span>
               </th>
               <th data-sortable="true"
+                  data-sort-type="status"
+                  class="sortable"
+                  style="cursor: pointer"
+                  title="Latest file manufacturability check status">
+                Latest <span class="sort-indicator"></span>
+              </th>
+              <th data-sortable="true"
                   data-sort-type="date"
                   class="sortable text-center"
                   style="cursor: pointer;
@@ -123,7 +130,8 @@
               <th data-sortable="true"
                   data-sort-type="status"
                   class="sortable"
-                  style="cursor: pointer">
+                  style="cursor: pointer"
+                  title="Submitted file manufacturability check status">
                 Status <span class="sort-indicator"></span>
               </th>
               <th>Slots</th>
@@ -142,6 +150,12 @@
                 <td data-sort-value="{{ project.slot_size }}">
                   <span class="badge bg-secondary">{{ project.get_slot_size_display }}</span>
                 </td>
+                {# Latest file check - may differ from submitted file #}
+                {% with latest_check=project.latest_file_manufacturability_check %}
+                  <td data-sort-value="{% if latest_check.is_manufacturable %}0{% elif latest_check.is_manufacturable is None %}2{% else %}1{% endif %}">
+                    {% badge_check_status_and_version latest_check %}
+                  </td>
+                {% endwith %}
                 <td class="text-center"
                     data-sort-value="{{ project.submitted_at|date:'Y-m-d H:i:s'|default:'' }}"
                     title="{{ project.submitted_at|date:'Y-m-d H:i:s'|default:'—' }}">
@@ -151,7 +165,7 @@
                     <i class="bi bi-x-lg text-danger"></i>
                   {% endif %}
                 </td>
-                {# Sort order: Ready(0) < Failed(1) < Pending(2) - prioritizes actionable projects #}
+                {# Submitted file check - Sort order: Ready(0) < Failed(1) < Pending(2) #}
                 <td data-sort-value="{% if project.is_manufacturable %}0{% elif project.is_manufacturable is None %}2{% else %}1{% endif %}">
                   {% with check=project.latest_manufacturability_check %}
                     {% badge_check_status_and_version check %}


### PR DESCRIPTION
## Summary

- Add a new "Latest" column to the shuttle assignment dashboard showing the manufacturability check status for the most recent file (by ID) for each project
- This differs from the existing "Status" column which shows the check for the submitted file

## Changes

- Add `latest_file` property to Project model (returns most recent file by ID)  
- Add `latest_file_manufacturability_check` property to Project model
- Add "Latest" column to assignment dashboard between Size and Submitted columns

## Use Case

This helps admins see if a project's most recent upload passes checks, even if a different file was submitted for manufacturing. For example:
- A project was submitted with file A (passing)
- User uploads new file B (failing)
- "Status" shows: Passed (for submitted file A)
- "Latest" shows: Failed (for latest file B)

## Test plan

- [x] All 1249 existing tests pass
- [ ] Manual verification: View shuttle assignment dashboard and verify new column appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Latest" column to the project assignment dashboard displaying the most recent manufacturability check status for each project.
  * Column includes sorting capability for improved organization and filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->