### PR TITLE
Register missing project models in Django admin (#248)

### DIFF
--- a/wafer_space/projects/admin.py
+++ b/wafer_space/projects/admin.py
@@ -8,6 +8,12 @@ from wafer_space.projects.models import ManufacturabilityCheck
 from wafer_space.projects.models import PrecheckImageRevision
 from wafer_space.projects.models import Project
 from wafer_space.projects.models import ProjectAccessLog
+from wafer_space.projects.models import DownloadAttempt
+from wafer_space.projects.models import FileProcessingError
+from wafer_space.projects.models import ProjectFileChunk
+from wafer_space.projects.models import ManufacturabilityCheckTask
+from wafer_space.projects.models import ManufacturabilityCheckpoint
+
 
 
 @admin.register(Project)
@@ -261,20 +267,8 @@ class PrecheckImageRevisionAdmin(admin.ModelAdmin):
 # Import compliance admin to register it
 from .admin_compliance import ProjectComplianceCertificationAdmin  # noqa: E402, F401
 
-'''
---------------------------------------------------------------
-admin models for FileProcessingError, DownloadAttempt, ProjectFileChunk, ManufacturabilityCheckTask, ManufacturabilityCheckpoint
- issue #248
- --------------------------------------------------------------
- '''
-from wafer_space.projects.models import (
-    DownloadAttempt,
-    FileProcessingError,
-    ProjectFileChunk,
-    ManufacturabilityCheckTask,
-    ManufacturabilityCheckpoint
-)
-from wafer_space.contrib.admin_mixins import StaffReadOnlyAdminMixin
+
+# Admin registrations for download/manufacturability audit models (issue #248)
 
 @admin.register(DownloadAttempt)
 class DownloadAttemptAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
@@ -319,7 +313,7 @@ class DownloadAttemptAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
 
     ordering = ("-started_at",)
 
-    def download_progress_display(self, obj):
+    def download_progress_display(self, obj: DownloadAttempt) -> str:
         return f"{obj.download_progress}%"
 
     download_progress_display.short_description = "Progress"
@@ -354,7 +348,7 @@ class FileProcessingErrorAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
 
     ordering = ("-occurred_at",)
 
-    def error_message_preview(self, obj):
+    def error_message_preview(self, obj: FileProcessingError) -> str:
         return obj.error_message[:75]
 
     error_message_preview.short_description = "Error Message"

--- a/wafer_space/projects/admin.py
+++ b/wafer_space/projects/admin.py
@@ -4,16 +4,15 @@ from django.contrib import admin
 from simple_history.admin import SimpleHistoryAdmin
 
 from wafer_space.contrib.admin_mixins import StaffReadOnlyAdminMixin
+from wafer_space.projects.models import DownloadAttempt
+from wafer_space.projects.models import FileProcessingError
 from wafer_space.projects.models import ManufacturabilityCheck
+from wafer_space.projects.models import ManufacturabilityCheckpoint
+from wafer_space.projects.models import ManufacturabilityCheckTask
 from wafer_space.projects.models import PrecheckImageRevision
 from wafer_space.projects.models import Project
 from wafer_space.projects.models import ProjectAccessLog
-from wafer_space.projects.models import DownloadAttempt
-from wafer_space.projects.models import FileProcessingError
 from wafer_space.projects.models import ProjectFileChunk
-from wafer_space.projects.models import ManufacturabilityCheckTask
-from wafer_space.projects.models import ManufacturabilityCheckpoint
-
 
 
 @admin.register(Project)
@@ -267,8 +266,8 @@ class PrecheckImageRevisionAdmin(admin.ModelAdmin):
 # Import compliance admin to register it
 from .admin_compliance import ProjectComplianceCertificationAdmin  # noqa: E402, F401
 
-
 # Admin registrations for download/manufacturability audit models (issue #248)
+
 
 @admin.register(DownloadAttempt)
 class DownloadAttemptAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
@@ -313,10 +312,10 @@ class DownloadAttemptAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
 
     ordering = ("-started_at",)
 
+    @admin.display(description="Progress")
     def download_progress_display(self, obj: DownloadAttempt) -> str:
         return f"{obj.download_progress}%"
 
-    download_progress_display.short_description = "Progress"
 
 @admin.register(FileProcessingError)
 class FileProcessingErrorAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
@@ -348,10 +347,10 @@ class FileProcessingErrorAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
 
     ordering = ("-occurred_at",)
 
+    @admin.display(description="Error Message")
     def error_message_preview(self, obj: FileProcessingError) -> str:
         return obj.error_message[:75]
 
-    error_message_preview.short_description = "Error Message"
 
 @admin.register(ProjectFileChunk)
 class ProjectFileChunkAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
@@ -363,13 +362,9 @@ class ProjectFileChunkAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
         "timestamp",
     )
 
-    list_filter = (
-        "timestamp",
-    )
+    list_filter = ("timestamp",)
 
-    search_fields = (
-        "download_attempt__project_file__original_filename",
-    )
+    search_fields = ("download_attempt__project_file__original_filename",)
 
     readonly_fields = (
         "download_attempt",
@@ -379,6 +374,7 @@ class ProjectFileChunkAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
     )
 
     ordering = ("download_attempt", "chunk_number")
+
 
 @admin.register(ManufacturabilityCheckTask)
 class ManufacturabilityCheckTaskAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
@@ -395,9 +391,7 @@ class ManufacturabilityCheckTaskAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin)
         "queued_at",
     )
 
-    search_fields = (
-        "task_id",
-    )
+    search_fields = ("task_id",)
 
     readonly_fields = (
         "manufacturability_check",
@@ -407,6 +401,7 @@ class ManufacturabilityCheckTaskAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin)
     )
 
     ordering = ("-queued_at",)
+
 
 @admin.register(ManufacturabilityCheckpoint)
 class ManufacturabilityCheckpointAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
@@ -425,9 +420,7 @@ class ManufacturabilityCheckpointAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin
         "container_state",
     )
 
-    search_fields = (
-        "manufacturability_check__id",
-    )
+    search_fields = ("manufacturability_check__id",)
 
     readonly_fields = (
         "manufacturability_check",

--- a/wafer_space/projects/admin.py
+++ b/wafer_space/projects/admin.py
@@ -260,3 +260,200 @@ class PrecheckImageRevisionAdmin(admin.ModelAdmin):
 
 # Import compliance admin to register it
 from .admin_compliance import ProjectComplianceCertificationAdmin  # noqa: E402, F401
+
+'''
+--------------------------------------------------------------
+admin models for FileProcessingError, DownloadAttempt, ProjectFileChunk, ManufacturabilityCheckTask, ManufacturabilityCheckpoint
+ issue #248
+ --------------------------------------------------------------
+ '''
+from wafer_space.projects.models import (
+    DownloadAttempt,
+    FileProcessingError,
+    ProjectFileChunk,
+    ManufacturabilityCheckTask,
+    ManufacturabilityCheckpoint
+)
+from wafer_space.contrib.admin_mixins import StaffReadOnlyAdminMixin
+
+@admin.register(DownloadAttempt)
+class DownloadAttemptAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "project_file",
+        "attempt_number",
+        "status",
+        "bytes_downloaded",
+        "download_progress_display",
+        "started_at",
+        "completed_at",
+        "last_activity",
+    )
+
+    list_filter = (
+        "status",
+        "started_at",
+        "completed_at",
+    )
+
+    search_fields = (
+        "project_file__original_filename",
+        "worker_hostname",
+    )
+
+    readonly_fields = (
+        "project_file",
+        "attempt_number",
+        "status",
+        "started_at",
+        "completed_at",
+        "download_started_at",
+        "download_completed_at",
+        "download_duration_seconds",
+        "bytes_downloaded",
+        "worker_pid",
+        "worker_hostname",
+        "task_started_at",
+        "last_activity",
+    )
+
+    ordering = ("-started_at",)
+
+    def download_progress_display(self, obj):
+        return f"{obj.download_progress}%"
+
+    download_progress_display.short_description = "Progress"
+
+@admin.register(FileProcessingError)
+class FileProcessingErrorAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "download_attempt",
+        "error_type",
+        "error_message_preview",
+        "occurred_at",
+    )
+
+    list_filter = (
+        "error_type",
+        "occurred_at",
+    )
+
+    search_fields = (
+        "error_message",
+        "download_attempt__project_file__original_filename",
+    )
+
+    readonly_fields = (
+        "download_attempt",
+        "error_type",
+        "error_message",
+        "error_detail",
+        "occurred_at",
+    )
+
+    ordering = ("-occurred_at",)
+
+    def error_message_preview(self, obj):
+        return obj.error_message[:75]
+
+    error_message_preview.short_description = "Error Message"
+
+@admin.register(ProjectFileChunk)
+class ProjectFileChunkAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "download_attempt",
+        "chunk_number",
+        "bytes_downloaded",
+        "timestamp",
+    )
+
+    list_filter = (
+        "timestamp",
+    )
+
+    search_fields = (
+        "download_attempt__project_file__original_filename",
+    )
+
+    readonly_fields = (
+        "download_attempt",
+        "chunk_number",
+        "bytes_downloaded",
+        "timestamp",
+    )
+
+    ordering = ("download_attempt", "chunk_number")
+
+@admin.register(ManufacturabilityCheckTask)
+class ManufacturabilityCheckTaskAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "manufacturability_check",
+        "task_name",
+        "task_id",
+        "queued_at",
+    )
+
+    list_filter = (
+        "task_name",
+        "queued_at",
+    )
+
+    search_fields = (
+        "task_id",
+    )
+
+    readonly_fields = (
+        "manufacturability_check",
+        "task_name",
+        "task_id",
+        "queued_at",
+    )
+
+    ordering = ("-queued_at",)
+
+@admin.register(ManufacturabilityCheckpoint)
+class ManufacturabilityCheckpointAdmin(StaffReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "manufacturability_check",
+        "checkpoint_number",
+        "elapsed_seconds",
+        "cpu_percent_formatted",
+        "memory_usage_formatted",
+        "timestamp",
+    )
+
+    list_filter = (
+        "timestamp",
+        "container_state",
+    )
+
+    search_fields = (
+        "manufacturability_check__id",
+    )
+
+    readonly_fields = (
+        "manufacturability_check",
+        "checkpoint_number",
+        "elapsed_seconds",
+        "timestamp",
+        "cpu_percent",
+        "cpu_total_usage",
+        "cpu_system_usage",
+        "cpu_online_cpus",
+        "memory_usage_bytes",
+        "memory_limit_bytes",
+        "memory_percent",
+        "memory_cache_bytes",
+        "block_read_bytes",
+        "block_write_bytes",
+        "network_rx_bytes",
+        "network_tx_bytes",
+        "container_state",
+        "raw_stats_json",
+    )
+
+    ordering = ("manufacturability_check", "checkpoint_number")


### PR DESCRIPTION
## Summary

Registers previously unexposed `wafer_space.projects` models in Django Admin
to improve observability and debugging of file downloads and manufacturability
checks.

## Models added to admin

- DownloadAttempt
- FileProcessingError
- ProjectFileChunk
- ManufacturabilityCheckTask
- ManufacturabilityCheckpoint

## Notes

- All models are registered as **read-only** using `StaffReadOnlyAdminMixin`
- No behavior or schema changes
- No test data required (system-generated models)

Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only admin views for audit/historical records (download activity, file processing errors, project file chunks, and manufacturability checks) to improve visibility.
  * Enhanced admin display with progress percentage indicators and concise error message previews for easier monitoring and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->