### PR TITLE
fix: robust GDS/OASIS/archive upload file-type detection

### DIFF
--- a/wafer_space/projects/file_type_utils.py
+++ b/wafer_space/projects/file_type_utils.py
@@ -21,6 +21,17 @@ def detect_file_type_from_data(data: bytes) -> tuple[str, str]:
     Raises:
         ValueError: If file type is not a valid GDS/OASIS file
     """
+    # Detect zip by its leading signature before falling back to libmagic.
+    # libmagic identifies a zip via the End-Of-Central-Directory record at the
+    # *end* of the archive, which ``magic.from_buffer`` cannot seek to (and
+    # which is absent when only the first chunk of a large upload is passed).
+    # Recent libmagic (file 5.46) therefore reports a real zip as
+    # ``application/octet-stream`` in buffer mode, silently mislabelling
+    # ``.zip`` uploads as raw ``.gds``. The leading signature is unambiguous.
+    zip_signatures = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+    if data[:4] in zip_signatures:
+        return "application/zip", ".gds.zip"
+
     # Detect MIME type from data
     mime_detector = magic.Magic(mime=True)
     mime_type = mime_detector.from_buffer(data)

--- a/wafer_space/projects/file_type_utils.py
+++ b/wafer_space/projects/file_type_utils.py
@@ -6,59 +6,67 @@ Both services.py and tasks.py can import from this module.
 
 import magic
 
+# GDSII files begin with a HEADER record: 2-byte length (0x0006), 1-byte record
+# type (0x00 = HEADER), 1-byte data type (0x02 = two-byte integer).
+GDS_SIGNATURE = b"\x00\x06\x00\x02"
+
+# OASIS files begin with the magic string defined by SEMI P39/P44.
+OASIS_SIGNATURE = b"%SEMI-OASIS\r\n"
+
+# Zip local-file-header / empty-archive / spanned-archive signatures. Detected
+# explicitly because libmagic identifies a zip via the End-Of-Central-Directory
+# record at the *end* of the archive, which ``magic.from_buffer`` cannot seek to
+# (and which is absent when only the first chunk of a large upload is passed).
+# Recent libmagic (file 5.46) therefore reports a real zip as
+# ``application/octet-stream`` in buffer mode.
+ZIP_SIGNATURES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+
+# Compressed wrappers libmagic reliably identifies from their leading bytes.
+_COMPRESSED_MIME_TO_EXTENSION = {
+    "application/gzip": ".gds.gz",
+    "application/x-gzip": ".gds.gz",
+    "application/x-bzip2": ".gds.bz2",
+    "application/x-xz": ".gds.xz",
+}
+
 
 def detect_file_type_from_data(data: bytes) -> tuple[str, str]:
-    """Detect file type from actual file data using MIME type detection.
+    """Detect file type from actual file data.
+
+    GDS and OASIS files are identified by their own format signatures rather
+    than assuming any generic binary (``application/octet-stream``) is GDS.
+    Compressed archives (gzip/bzip2/xz/zip) wrapping a GDS/OASIS file are also
+    recognised. Anything else is rejected.
 
     Args:
         data: File data bytes (at least first 1MB recommended)
 
     Returns:
         tuple: (mime_type, file_extension)
-            - mime_type: Detected MIME type (e.g., "application/gzip")
-            - file_extension: Appropriate file extension (e.g., ".gds.gz")
+            - mime_type: Detected MIME type (e.g., "application/x-gds")
+            - file_extension: Appropriate file extension (e.g., ".gds")
 
     Raises:
-        ValueError: If file type is not a valid GDS/OASIS file
+        ValueError: If the file is not a GDS/OASIS file or a supported archive.
     """
-    # Detect zip by its leading signature before falling back to libmagic.
-    # libmagic identifies a zip via the End-Of-Central-Directory record at the
-    # *end* of the archive, which ``magic.from_buffer`` cannot seek to (and
-    # which is absent when only the first chunk of a large upload is passed).
-    # Recent libmagic (file 5.46) therefore reports a real zip as
-    # ``application/octet-stream`` in buffer mode, silently mislabelling
-    # ``.zip`` uploads as raw ``.gds``. The leading signature is unambiguous.
-    zip_signatures = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
-    if data[:4] in zip_signatures:
+    # Detect GDS/OASIS/zip by their leading signatures, independent of libmagic.
+    if data[:4] == GDS_SIGNATURE:
+        return "application/x-gds", ".gds"
+    if data.startswith(OASIS_SIGNATURE):
+        return "application/x-oasis", ".oas"
+    if data[:4] in ZIP_SIGNATURES:
         return "application/zip", ".gds.zip"
 
-    # Detect MIME type from data
+    # Fall back to libmagic for compressed wrappers.
     mime_detector = magic.Magic(mime=True)
     mime_type = mime_detector.from_buffer(data)
 
-    # Map MIME types to file extensions
-    # GDS/OASIS files are binary formats, often detected as generic binary
-    mime_to_extension = {
-        # Compressed formats
-        "application/gzip": ".gds.gz",  # Assume GDS compressed with gzip
-        "application/x-gzip": ".gds.gz",
-        "application/zip": ".gds.zip",
-        "application/x-zip-compressed": ".gds.zip",
-        "application/x-bzip2": ".gds.bz2",
-        "application/x-xz": ".gds.xz",
-        # Uncompressed - these are tricky as GDS/OASIS have no standard MIME type
-        "application/octet-stream": ".gds",  # Generic binary, assume GDS
-        "application/x-gds": ".gds",  # Non-standard but sometimes used
-        "application/x-oasis": ".oas",
-    }
-
-    if mime_type not in mime_to_extension:
+    extension = _COMPRESSED_MIME_TO_EXTENSION.get(mime_type)
+    if extension is None:
         msg = (
-            f"Unsupported file type: {mime_type}. "
-            f"Only GDS/OASIS files are accepted. "
-            f"Supported MIME types: {', '.join(sorted(mime_to_extension.keys()))}"
+            f"Unsupported file type: {mime_type}. Only GDS, OASIS, or "
+            f"gzip/bzip2/xz/zip-compressed GDS/OASIS files are accepted."
         )
         raise ValueError(msg)
 
-    extension = mime_to_extension[mime_type]
     return mime_type, extension

--- a/wafer_space/projects/tests/test_services.py
+++ b/wafer_space/projects/tests/test_services.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+import zipfile
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -571,6 +573,22 @@ class TestDetectFileType(TestCase):
         # ZIP magic bytes (PK header)
         zip_data = b"PK\x03\x04" + b"\x00" * 100
         mime_type, extension = detect_file_type_from_data(zip_data)
+        assert mime_type in ["application/zip", "application/x-zip-compressed"]
+        assert extension == ".gds.zip"
+
+    def test_detect_real_zip_file(self):
+        """A real zip archive is detected as zip, not silently treated as GDS.
+
+        Regression test for the libmagic buffer-mode discrepancy: libmagic
+        identifies a normal zip via the End-Of-Central-Directory record at the
+        end of the file, which ``magic.from_buffer`` cannot seek to. A genuine
+        zip (local-file-header signature ``PK\\x03\\x04``) must still map to
+        ``.gds.zip`` rather than falling through to ``octet-stream`` -> ``.gds``.
+        """
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("design.gds", b"fake gds payload" * 64)
+        mime_type, extension = detect_file_type_from_data(buf.getvalue())
         assert mime_type in ["application/zip", "application/x-zip-compressed"]
         assert extension == ".gds.zip"
 

--- a/wafer_space/projects/tests/test_services.py
+++ b/wafer_space/projects/tests/test_services.py
@@ -608,13 +608,28 @@ class TestDetectFileType(TestCase):
         assert mime_type == "application/x-xz"
         assert extension == ".gds.xz"
 
-    def test_detect_binary_file_as_gds(self):
-        """Test detection of generic binary file (assumed to be GDS)."""
-        # Generic binary data
-        binary_data = b"\x00\x01\x02\x03" + b"\x00" * 100
-        mime_type, extension = detect_file_type_from_data(binary_data)
-        assert mime_type == "application/octet-stream"
+    def test_detect_gds_file(self):
+        """A GDSII file is detected by its HEADER record signature."""
+        # GDSII files begin with a HEADER record: length=0x0006, record
+        # type=0x00 (HEADER), data type=0x02 (2-byte int), then the version.
+        gds_data = b"\x00\x06\x00\x02\x00\x05" + b"\x00" * 100
+        mime_type, extension = detect_file_type_from_data(gds_data)
+        assert mime_type == "application/x-gds"
         assert extension == ".gds"
+
+    def test_detect_oasis_file(self):
+        """An OASIS file is detected by its magic string, not mislabelled .gds."""
+        oasis_data = b"%SEMI-OASIS\r\n" + b"\x00" * 100
+        mime_type, extension = detect_file_type_from_data(oasis_data)
+        assert mime_type == "application/x-oasis"
+        assert extension == ".oas"
+
+    def test_reject_unknown_binary(self):
+        """Generic binary is rejected, not assumed to be GDS."""
+        # Generic binary data that is neither GDS, OASIS, nor a known archive.
+        binary_data = b"\x00\x01\x02\x03" + b"\x00" * 100
+        with pytest.raises(ValueError, match="Unsupported file type"):
+            detect_file_type_from_data(binary_data)
 
     def test_reject_text_file(self):
         """Test that text files are rejected."""


### PR DESCRIPTION
## Summary

Hardens `detect_file_type_from_data()` so upload file-type detection is explicit and robust, fixing three issues:

1. **Zip mis-detection (buffer mode).** libmagic identifies a zip via the End-Of-Central-Directory record at the *end* of the archive, which `magic.from_buffer()` cannot seek to. On `file` 5.46 (e.g. Debian 13) a real zip is reported as `application/octet-stream`, so compressed `.gds.zip` uploads were silently handled as raw GDS. The production caller passes only the first 1MB, so for zips larger than 1MB the EOCD is never present regardless of libmagic version. CI (`ubuntu-latest`, older libmagic) flagged zip from the leading `PK\x03\x04` signature in buffer mode, so the original synthetic-bytes test passed there and the gap went unnoticed.
2. **Generic binary assumed to be GDS.** Any `application/octet-stream` was mapped to `.gds`, so arbitrary binary was accepted as a design file.
3. **OASIS rejected.** OASIS files are detected by libmagic as `text/plain` and were rejected outright (and would otherwise have been mislabelled `.gds`).

## Fix

Detect GDS, OASIS, and zip by their own leading signatures, independent of libmagic version/mode:

- GDS: `\x00\x06\x00\x02` (GDSII HEADER record: length 6, type HEADER, 2-byte-int datatype) -> `.gds`
- OASIS: `%SEMI-OASIS\r\n` (SEMI P39/P44 magic) -> `.oas`
- zip: `PK\x03\x04` / `PK\x05\x06` / `PK\x07\x08` -> `.gds.zip`

libmagic is used only for the gzip/bzip2/xz wrappers, which it identifies reliably from their leading bytes. Anything else — including `application/octet-stream` — is rejected with a validation error rather than assumed to be GDS. The caller already handles `ValueError` (records a `FileProcessingError` and fails the download attempt).

## Testing

- New `test_detect_real_zip_file`, `test_detect_gds_file`, `test_detect_oasis_file`; `test_detect_binary_file_as_gds` replaced by `test_reject_unknown_binary` to reflect the new contract.
- `make lint` and `make type-check`: clean.
- Full unit suite: 1185 passed, 0 failed.

## Behavior change

Uploads that are neither GDS/OASIS nor a supported archive (gzip/bzip2/xz/zip) are now rejected with a clear validation error instead of being silently accepted as `.gds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP uploads are now reliably detected and mapped to the correct extension; generic binary data is no longer misclassified as GDS.

* **New Features**
  * Explicit detection added for uncompressed GDS and OASIS files so they are recognized immediately.

* **Tests**
  * Added regression tests covering ZIP, GDS, OASIS detection and rejection of unknown binary data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->